### PR TITLE
Update BlocktradesDeposit.jsx input type="tel"

### DIFF
--- a/app/components/modules/BlocktradesDeposit.jsx
+++ b/app/components/modules/BlocktradesDeposit.jsx
@@ -201,7 +201,7 @@ export default class BlocktradesDeposit extends React.Component {
                             <label className="float-left" htmlFor="estimateAmount"> Estimate using {estimateInputCoin}</label>
                             <span className="float-right" onClick={onFlip}>{flipIcon}</span>
                         </div>
-                        <input id="estimateAmount" type="text" {...cleanReduxInput(amount)} disabled={submitting}
+                        <input id="estimateAmount" type="tel" {...cleanReduxInput(amount)} disabled={submitting}
                             placeholder={`Amount to send ${estimateInputCoin}`}
                             autoComplete="off" ref="amountRef"
                         />


### PR DESCRIPTION
A quick UX tweak, to enable the numeric keypad to pop up on mobile (instead of the normal qwerty keyboard).