### PR TITLE
Pull Request: Adding Cancel All Button 

### DIFF
--- a/app/components/pages/Market.jsx
+++ b/app/components/pages/Market.jsx
@@ -51,7 +51,8 @@ class Market extends React.Component {
         const owner = user.get('username')
         const amount_to_sell = parseFloat(ReactDOM.findDOMNode(this.refs.buySteem_total).value)
         const min_to_receive = parseFloat(ReactDOM.findDOMNode(this.refs.buySteem_amount).value)
-        const price = (amount_to_sell / min_to_receive).toFixed(6)
+        const price = (amount_to_sell / min_to_receive).toFixed(8)
+        // Changed toFixex(8) because of rounding issue caused orderbook display.
         placeOrder(owner, amount_to_sell + " SBD", min_to_receive + " STEEM", "$" + price + "/STEEM", (msg) => {
             this.props.notify(msg)
             this.props.reload(owner)
@@ -64,7 +65,8 @@ class Market extends React.Component {
         const owner = user.get('username')
         const min_to_receive = parseFloat(ReactDOM.findDOMNode(this.refs.sellSteem_total).value)
         const amount_to_sell = parseFloat(ReactDOM.findDOMNode(this.refs.sellSteem_amount).value)
-        const price = (min_to_receive / amount_to_sell).toFixed(6)
+        const price = (min_to_receive / amount_to_sell).toFixed(8)
+        // Changed toFixex(8) because of rounding issue caused orderbook display.
         placeOrder(owner, amount_to_sell + " STEEM", min_to_receive + " SBD", "$" + price + "/STEEM", (msg) => {
             this.props.notify(msg)
             this.props.reload(owner)
@@ -80,6 +82,22 @@ class Market extends React.Component {
             this.props.reload(owner)
         })
     }
+
+    cancelAllOrderClick = (e, open_orders) => {
+        e.preventDefault()
+        return open_orders.map( o => {
+            const {cancelOrder, user} = this.props
+            if(!user) return
+            const owner = user.get('username')
+            cancelOrder(owner, o.orderid, (msg) => {
+                this.props.notify(msg)
+                this.props.reload(owner)
+            })
+        }
+    }
+
+
+    // Cancel all user orders
 
     setFormPrice = (price) => {
         const p = parseFloat(price)
@@ -212,6 +230,7 @@ class Market extends React.Component {
 
             })
         }
+
 
         // Logged-in user's open orders
         function open_orders_table(open_orders) {
@@ -489,7 +508,7 @@ class Market extends React.Component {
                 {account &&
                     <div className="row">
                         <div className="column">
-                            <h4>Open Orders</h4>
+                            <h4>Open Orders | <a href="#" onClick={e => cancelAllOrderClick(e, open_orders)}>Cancel All</a></h4>
                             {open_orders_table(open_orders)}
                         </div>
                     </div>}

--- a/app/components/pages/Market.jsx
+++ b/app/components/pages/Market.jsx
@@ -51,8 +51,8 @@ class Market extends React.Component {
         const owner = user.get('username')
         const amount_to_sell = parseFloat(ReactDOM.findDOMNode(this.refs.buySteem_total).value)
         const min_to_receive = parseFloat(ReactDOM.findDOMNode(this.refs.buySteem_amount).value)
-        const price = (amount_to_sell / min_to_receive).toFixed(8)
-        // Changed toFixex(8) because of rounding issue caused orderbook display.
+        const price = (amount_to_sell / min_to_receive).toFixed(6)
+        // Changed toFixex(8) because of rounding issue caused orderbook display?
         placeOrder(owner, amount_to_sell + " SBD", min_to_receive + " STEEM", "$" + price + "/STEEM", (msg) => {
             this.props.notify(msg)
             this.props.reload(owner)
@@ -65,8 +65,8 @@ class Market extends React.Component {
         const owner = user.get('username')
         const min_to_receive = parseFloat(ReactDOM.findDOMNode(this.refs.sellSteem_total).value)
         const amount_to_sell = parseFloat(ReactDOM.findDOMNode(this.refs.sellSteem_amount).value)
-        const price = (min_to_receive / amount_to_sell).toFixed(8)
-        // Changed toFixex(8) because of rounding issue caused orderbook display.
+        const price = (min_to_receive / amount_to_sell).toFixed(6)
+        // Changed toFixex(8) because of rounding issue caused orderbook display?
         placeOrder(owner, amount_to_sell + " STEEM", min_to_receive + " SBD", "$" + price + "/STEEM", (msg) => {
             this.props.notify(msg)
             this.props.reload(owner)

--- a/app/components/pages/Post.jsx
+++ b/app/components/pages/Post.jsx
@@ -80,7 +80,7 @@ class Post extends React.Component {
                 </div>
 
                 //@Jasonmcz
-                //Comment: Perhaps it would be good to havd a render/timeout
+                //Comment: Perhaps it would be good to HAVE a render/timeout
                 //Because it takes about 5-15 seconds right now to load an account
                 //which pretty much shows up the promotion of $10.00 STEEM every single time
                 //perhaps add a timeout here prior to render this?

--- a/app/components/pages/Post.jsx
+++ b/app/components/pages/Post.jsx
@@ -58,7 +58,7 @@ class Post extends React.Component {
         let sort_menu = [];
 
         let selflink = '/' + rout_params.category +'/@'+ rout_params.username + '/' + rout_params.slug;
-        for( let o = 0; o < sort_orders.length; ++o ){ 
+        for( let o = 0; o < sort_orders.length; ++o ){
             sort_menu.push({
                 value: sort_orders[o],
                 label: sort_labels[o],
@@ -78,6 +78,13 @@ class Post extends React.Component {
                         <PostFull post={post} global={g} />
                     </div>
                 </div>
+
+                //@Jasonmcz
+                //Comment: Perhaps it would be good to havd a render/timeout
+                //Because it takes about 5-15 seconds right now to load an account
+                //which pretty much shows up the promotion of $10.00 STEEM every single time
+                //perhaps add a timeout here prior to render this?
+
                 {!current_user && <div className="row">
                     <div className="column">
                       <div className="Post__promo">

--- a/app/components/pages/PostsIndex.jsx
+++ b/app/components/pages/PostsIndex.jsx
@@ -82,4 +82,3 @@ module.exports = {
         }
     )(PostsIndex)
 };
-


### PR DESCRIPTION
**Goal:**
```
-an easier cancellation process for GUI traders on internal market 
-cancelling 10+ orders one by one can be difficult on the GUI level especially with the each reload the order sequence changes after the table gets  re-constructed 
```

**Changed:**
```
-looping through open_orders array 
-cancel each individual orders
-notify users about cancellation ( might be better just send one message after map is done?)
-reload the front-end
```

Note: Please take a look, I didn't have `STEEMD` on my environment so I wasn't able to test the function by running it locally.