### PR TITLE
Show the additional witnesses you have voted for outside of the top 50

### DIFF
--- a/app/components/pages/Witnesses.jsx
+++ b/app/components/pages/Witnesses.jsx
@@ -73,6 +73,29 @@ class Witnesses extends React.Component {
             )
         });
 
+        let addl_witnesses = false;
+        if(witness_votes) {
+            addl_witnesses = witness_votes.filter(function(item) {
+                return !sorted_witnesses.has(item)
+            }).map(item => {
+                return (
+                       <div className="row" key={item}>
+                           <div className="column small-12">
+                              <span>{/*className="Voting"*/}
+                                  <span className="Voting__button Voting__button-up space-right Voting__button--upvoted">
+                                      <a href="#" onClick={accountWitnessVote.bind(this, item, false)}
+                                          title="Vote">{up}</a>
+                                      &nbsp;
+                                  </span>
+                              </span>
+                             <Link to={'/@'+item}>{item}</Link>
+                           </div>
+                       </div>
+                )
+            }).toArray();
+        }
+
+
       return (
         <div>
         <div className="Witnesses row">
@@ -81,19 +104,21 @@ class Witnesses extends React.Component {
 
           {header}
           <div className="Witnesses row">
-            <div className="column small-12">         
+            <div className="column small-12">
                  {witnesses.toArray()}
             </div>
           </div>
-          <hr/>          
+          <hr/>
           <div className="row">
             <div className="column small-6">
-              <p>If the witness is not in the top 50, enter their username here to cast a vote.</p>
-              <form>
-                <input type="text" style={{float: "left", width: "75%"}} value={customUsername} onChange={onWitnessChange} />
-                <button className="darkbtn" onClick={accountWitnessVote.bind(this, customUsername, !(witness_votes ? witness_votes.has(customUsername) : null))}>Vote</button>
-              </form>
-              <br/><br/>
+                <p>If the witness is not in the top 50, enter their username here to cast a vote.</p>
+                <form>
+                    <input type="text" style={{float: "left", width: "75%"}} value={customUsername} onChange={onWitnessChange} />
+                    <button className="darkbtn" onClick={accountWitnessVote.bind(this, customUsername, !(witness_votes ? witness_votes.has(customUsername) : null))}>Vote</button>
+                </form>
+                <br/>
+                {addl_witnesses}
+                <br/><br/>
              </div>
           </div>
       </div>


### PR DESCRIPTION
After talking with a few people, there was some confusion as to whether
votes were actually being applied to people outside of the top 50. This
change adds those users below the input box, and also lets them upcast
their votes by clicking the button.

- The additional witnesses are loaded off the current user's `witness_votes` profile field. 
- Any witnesses in the top 50 are filtered out.
- Entering a username and voting will add the username to the list below.
- Clicking the blue vote will uncast the vote, removing the user.

![image](https://cloud.githubusercontent.com/assets/677686/17802720/d31fff3c-65a6-11e6-80bf-218e9d2ce04c.png)
