### PR TITLE
Added witness url + remaining votes

### DIFF
--- a/app/components/pages/Witnesses.jsx
+++ b/app/components/pages/Witnesses.jsx
@@ -39,42 +39,37 @@ class Witnesses extends React.Component {
        const sorted_witnesses = global.getIn(['witnesses'])
             .sort((a, b) => Long.fromString(b.get('votes')).subtract(Long.fromString(a.get('votes')).toString()));
 
-        const header =
-            <div className="row">
-                <div className="column small-1">
-                    <label>Vote</label>
-                </div>
-                <div className="column small-4">
-                    <label>Witness</label>
-                </div>
-            </div>
         const up = <Icon name="chevron-up-circle" />;
+        let witness_votes_count = 30
         let rank = 1
         const witnesses = sorted_witnesses.map(item => {
             const owner = item.get('owner')
+            const thread = item.get('url')
             const myVote = witness_votes ? witness_votes.has(owner) : null
-            const classUp = 'Voting__button Voting__button-up space-right' +
+            const classUp = 'Voting__button Voting__button-up' +
                 (myVote === true ? ' Voting__button--upvoted' : '');
             return (
-                   <div className="row" key={owner}>
-                       <div className="column small-12">
-                          <span>{/*className="Voting"*/}
-                              {(rank < 10) && '0'}{rank++}
-                              &nbsp;&nbsp;
-                              <span className={classUp}>
-                                  <a href="#" onClick={accountWitnessVote.bind(this, owner, !myVote)}
-                                      title="Vote">{up}</a>
-                                  &nbsp;
-                              </span>
-                          </span>
-                         <Link to={'/@'+owner}>{owner}</Link>
-                       </div>
-                   </div>
+                    <tr key={owner}>
+                        <td width="75">
+                            {(rank < 10) && '0'}{rank++}
+                            &nbsp;&nbsp;
+                            <span className={classUp}>
+                                <a href="#" onClick={accountWitnessVote.bind(this, owner, !myVote)} title="Vote">{up}</a>
+                            </span>
+                        </td>
+                        <td>
+                            <Link to={'/@'+owner}>{owner}</Link>
+                        </td>
+                        <td>
+                            <Link to={thread}>witness thread</Link>
+                        </td>
+                    </tr>
             )
         });
 
         let addl_witnesses = false;
         if(witness_votes) {
+            witness_votes_count -= witness_votes.size
             addl_witnesses = witness_votes.filter(function(item) {
                 return !sorted_witnesses.has(item)
             }).map(item => {
@@ -96,34 +91,45 @@ class Witnesses extends React.Component {
         }
 
 
-      return (
-        <div>
-        <div className="Witnesses row">
-           <h2>Top Witnesses</h2>
-        </div>
-
-          {header}
-          <div className="Witnesses row">
-            <div className="column small-12">
-                 {witnesses.toArray()}
+        return (
+            <div>
+                <div className="row">
+                    <div className="column">
+                        <h2>Top Witnesses</h2>
+                        <p>
+                            <strong>You have {witness_votes_count} votes remaining.</strong>
+                            You can vote for a maximum of 30 witnesses.
+                        </p>
+                    </div>
+                </div>
+                <table>
+                    <thead>
+                        <tr>
+                            <th></th>
+                            <th>Witness</th>
+                            <th>Information</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {witnesses.toArray()}
+                    </tbody>
+                </table>
+                <hr/>
+                <div className="row">
+                    <div className="column small-12">
+                        <p>If you would like to vote for a witness outside of the top 50, enter the account name below to cast a vote.</p>
+                        <form>
+                            <input type="text" style={{float: "left", width: "75%"}} value={customUsername} onChange={onWitnessChange} />
+                            <button className="darkbtn" onClick={accountWitnessVote.bind(this, customUsername, !(witness_votes ? witness_votes.has(customUsername) : null))}>Vote</button>
+                        </form>
+                        <br/>
+                        {addl_witnesses}
+                        <br/><br/>
+                     </div>
+                </div>
             </div>
-          </div>
-          <hr/>
-          <div className="row">
-            <div className="column small-6">
-                <p>If the witness is not in the top 50, enter their username here to cast a vote.</p>
-                <form>
-                    <input type="text" style={{float: "left", width: "75%"}} value={customUsername} onChange={onWitnessChange} />
-                    <button className="darkbtn" onClick={accountWitnessVote.bind(this, customUsername, !(witness_votes ? witness_votes.has(customUsername) : null))}>Vote</button>
-                </form>
-                <br/>
-                {addl_witnesses}
-                <br/><br/>
-             </div>
-          </div>
-      </div>
-      );
-   }
+        );
+    }
 }
 
 

--- a/app/components/pages/Witnesses.jsx
+++ b/app/components/pages/Witnesses.jsx
@@ -48,6 +48,10 @@ class Witnesses extends React.Component {
             const myVote = witness_votes ? witness_votes.has(owner) : null
             const classUp = 'Voting__button Voting__button-up' +
                 (myVote === true ? ' Voting__button--upvoted' : '');
+            let witness_thread = ""
+            if(thread) {
+                witness_thread = <Link to={thread}>witness thread</Link>
+            }
             return (
                     <tr key={owner}>
                         <td width="75">
@@ -61,7 +65,7 @@ class Witnesses extends React.Component {
                             <Link to={'/@'+owner}>{owner}</Link>
                         </td>
                         <td>
-                            <Link to={thread}>witness thread</Link>
+                            {witness_thread}
                         </td>
                     </tr>
             )


### PR DESCRIPTION
Spent a little time this evening tinkering with the witnesses page again. I've made some modifications including:

- The witness URL has been added as a link to the right most column. 
- A small description has been added to the top of the page with how many remaining votes you have left along with the maximum.
- I thought some visual distinction and columns would do it justice, so I converted it into a table.
- Mobile optimizations for the "additional witnesses" section.

![image](https://cloud.githubusercontent.com/assets/677686/17836200/3a1979b4-673e-11e6-9990-949bfd9828d8.png)

I'm curious to know what other type of basic information should be added to this page. I choose not to add the price feed, misses, blocks and more advanced user information just to help avoid confusion. 