### PR TITLE
Added conditional header to posts for posts with depth > 0

### DIFF
--- a/app/components/cards/PostFull.jsx
+++ b/app/components/cards/PostFull.jsx
@@ -195,6 +195,14 @@ export default class PostFull extends React.Component {
         let post_header = <h1 className="entry-title">{content.title}</h1>
         if(content.depth > 0) {
             let parent_link = `/@${content.parent_author}/${content.parent_permlink}`;
+            let direct_parent_link
+            if(content.depth > 1) {
+                direct_parent_link = <li>
+                    <Link to={parent_link}>
+                        View the direct parent
+                    </Link>
+                </li>
+            }
             if (content.category) parent_link = `/${content.category}${parent_link}`;
             post_header = <div className="callout">
                 <h5>You are viewing a single comment&#39;s thread from:</h5>
@@ -207,11 +215,7 @@ export default class PostFull extends React.Component {
                             View the full context
                         </Link>
                     </li>
-                    <li>
-                        <Link to={parent_link}>
-                            View the direct parent
-                        </Link>
-                    </li>
+                    {direct_parent_link}
                 </ul>
             </div>
         }

--- a/app/components/cards/PostFull.jsx
+++ b/app/components/cards/PostFull.jsx
@@ -192,11 +192,35 @@ export default class PostFull extends React.Component {
         const showEditOption = username === author && total_payout === 0
         const authorRepLog10 = repLog10(content.author_reputation)
 
+        let post_header = <h1 className="entry-title">{content.title}</h1>
+        if(content.depth > 0) {
+            let parent_link = `/@${content.parent_author}/${content.parent_permlink}`;
+            if (content.category) parent_link = `/${content.category}${parent_link}`;
+            post_header = <div className="callout">
+                <h5>You are viewing a single comment&#39;s thread from:</h5>
+                <p>
+                    {content.root_title}
+                </p>
+                <ul>
+                    <li>
+                        <Link to={content.url}>
+                            View the full context
+                        </Link>
+                    </li>
+                    <li>
+                        <Link to={parent_link}>
+                            View the direct parent
+                        </Link>
+                    </li>
+                </ul>
+            </div>
+        }
+
         return (
             <article className="PostFull hentry" itemScope itemType ="http://schema.org/blogPost">
                 <div className="float-right"><Voting post={post} flag /></div>
                 <div className="PostFull__header">
-                    <h1 className="entry-title">{content.title}</h1>
+                    {post_header}
                     <TimeAuthorCategory content={content} authorRepLog10={authorRepLog10} showTags />
                 </div>
                 {showEdit ?


### PR DESCRIPTION
[@bitcoiner posted this feature request](https://steemit.com/tag/@bitcoiner/steemit-improvement-idea-give-a-link-to-the-parent-post) in response to some of the links I've been using on steemstats.com. These links leave steemstats.com and go directly to a reply, like so:

[https://steemit.com/tag/@jesta/re-bitcoiner-steemit-improvement-idea-give-a-link-to-the-parent-post-20160822t051520448z](https://steemit.com/tag/@jesta/re-bitcoiner-steemit-improvement-idea-give-a-link-to-the-parent-post-20160822t051520448z)

It's been incredibly useful to leave steemstats, immediately land on a reply, and be able to write a response. The only pain point is that there's no navigation on this page like you would get on reddit. So I propose the following change if `content.depth > 0`:

![image](https://cloud.githubusercontent.com/assets/677686/17845099/0dc61dc0-67f4-11e6-9ae8-951b0faf016c.png)

The two links will either:

- Bring you to the full context of the post.
- Load the direct parent of the reply you're reading.

This will likely also be useful in the future if steemit.com implements a notification system - as it will be easier to drop them on URLs like this than load the full post + scroll.