### PR TITLE
Fixing desktop rows on witness page

### DIFF
--- a/app/components/pages/Witnesses.jsx
+++ b/app/components/pages/Witnesses.jsx
@@ -106,21 +106,21 @@ class Witnesses extends React.Component {
                         </p>
                     </div>
                 </div>
-                <table>
-                    <thead>
-                        <tr>
-                            <th></th>
-                            <th>Witness</th>
-                            <th>Information</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {witnesses.toArray()}
-                    </tbody>
-                </table>
-                <hr/>
-                <div className="row">
+                <div className="row small-collapse">
                     <div className="column small-12">
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th></th>
+                                    <th>Witness</th>
+                                    <th>Information</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {witnesses.toArray()}
+                            </tbody>
+                        </table>
+                        <hr/>
                         <p>If you would like to vote for a witness outside of the top 50, enter the account name below to cast a vote.</p>
                         <form>
                             <input type="text" style={{float: "left", width: "75%"}} value={customUsername} onChange={onWitnessChange} />


### PR DESCRIPTION
It was not my intent to make the the witness page go full width. This PR moves the table into the grid/column layout that and uses the `small-collapse` class on the row to avoid impacting mobile layout.