### PR TITLE
Input filter style fix

### DIFF
--- a/app/components/all.scss
+++ b/app/components/all.scss
@@ -44,3 +44,4 @@
 @import "./pages/Tos";
 @import "./pages/UserProfile";
 @import "./pages/Market";
+@import "./pages/TagsIndex";

--- a/app/components/pages/TagsIndex.jsx
+++ b/app/components/pages/TagsIndex.jsx
@@ -53,7 +53,7 @@ class TagsIndex extends React.Component {
         return (
             <div className="TagsIndex row">
                 <div className="column">
-                    <div className="float-right">
+                    <div className="medium-2 medium-offset-10">
                         <input type="text" placeholder="Filter" value={search} onChange={this.onChangeSearch} />
                     </div>
                     <table>

--- a/app/components/pages/TagsIndex.scss
+++ b/app/components/pages/TagsIndex.scss
@@ -1,0 +1,6 @@
+.TagsIndex {
+    input {
+        margin-bottom: 0.5rem!important;
+    }
+}
+


### PR DESCRIPTION
This is slight UI/CSS improvement for the filter search input on the tag index page.  The input margins where being overridden by !important from the parent.  The search input is also improved to be responsive for mobile/tablet devices. 
<img width="398" alt="screen shot 2016-08-25 at 8 01 14 am" src="https://cloud.githubusercontent.com/assets/1158463/17974832/7b7320d4-6a9c-11e6-8164-8aa1711acf87.png">
