### PR TITLE
A11y - outline: none on all links

### DIFF
--- a/app/assets/stylesheets/foundation-overrides.scss
+++ b/app/assets/stylesheets/foundation-overrides.scss
@@ -2,10 +2,6 @@
   line-height: 1.5rem;
 }
 
-.menu > li > a:focus {
-  outline: none;
-}
-
 .tooltip {
   margin-top: -1rem;
 }
@@ -21,10 +17,6 @@
 
 div[role=dialog] {
   z-index: 500;
-}
-
-:focus {
-  outline: none;
 }
 
 input[type=submit].disabled, input[type=submit].disabled:focus {


### PR DESCRIPTION
Removing outlines on links hampers the accessibility of the site for people with impaired vision etc. Thus it is important not to disable outlines as they are there for a reason.
I'm creating this pull-request at the same time as I'm publishing a post on steemit with a list of changes that should be implemented to try and make steemit as accessible as possible, so sadly it isn't of the highest quality. I'm making this mostly as a suggestion and to raise awareness.

Link to post:
https://steemit.com/accessibility/@novium/steem-it-a11y-accessibility-project-make-steem-accessible-for-everyone