### PR TITLE
No errors if HtmlReady is given a blank string

### DIFF
--- a/shared/HtmlReady.js
+++ b/shared/HtmlReady.js
@@ -32,7 +32,7 @@ export default function (html, {mutate = true} = {}) {
         if(mutate) proxifyImages(doc)
         // console.log('state', state)
         if(!mutate) return state
-        return {html: XMLSerializer.serializeToString(doc), ...state}
+        return {html: (doc) ? XMLSerializer.serializeToString(doc) : '', ...state}
     }catch(error) {
         // Not Used, parseFromString might throw an error in the future
         console.error(error.toString())
@@ -89,6 +89,7 @@ function img(state, child) {
 // For all img elements with non-local URLs, prepend the proxy URL (e.g. `https://img0.steemit.com/0x0/`)
 function proxifyImages(doc) {
     if (!$STM_Config.img_proxy_prefix) return
+    if (!doc) return;
     [...doc.getElementsByTagName('img')].forEach(node => {
         const url = node.getAttribute('src')
         if(! linksRe.local.test(url))


### PR DESCRIPTION
A small little edit so no errors are made if given a blank string. I was playing with this module directly for a project I'm working on and noticed that empty string caused errors because `doc` would be undefined when calling `DOMParser.parseFromString` with a blank string.

So this checks if doc is defined before calling `serializeToString` and within `proxifyImages` before the forEach loop.
