### PR TITLE
A11y - Fix alt text on images

### DIFF
--- a/app/utils/SanitizeConfig.js
+++ b/app/utils/SanitizeConfig.js
@@ -52,7 +52,7 @@ export default ({large = true, highQualityPost = true, noImage = false, sanitize
 
         // style is subject to attack, filtering more below
         td: ['style'],
-        img: ['src'],
+        img: ['src', 'alt'],
         a: ['href', 'rel'],
     },
     transformTags: {
@@ -83,7 +83,7 @@ export default ({large = true, highQualityPost = true, noImage = false, sanitize
         img: (tagName, attribs) => {
             if(noImage) return {tagName: 'div', text: noImageText}
             //See https://github.com/punkave/sanitize-html/issues/117
-            let {src} = attribs
+            let {src, alt} = attribs
             if(!/^(https?:)?\/\//i.test(src)) {
                 console.log('Blocked, image tag src does not appear to be a url', tagName, attribs)
                 sanitizeErrors.push('Image URL does not appear to be valid: ' + src)
@@ -93,7 +93,7 @@ export default ({large = true, highQualityPost = true, noImage = false, sanitize
             // replace http:// with // to force https when needed
             src = src.replace(/^http:\/\//i, '//')
 
-            return {tagName, attribs: {src}}
+            return {tagName, attribs: {src, alt}}
         },
         div: (tagName, attribs) => {
             const attys = {}


### PR DESCRIPTION
Due to screenreaders not being able to just instantly recognize an image and it's contents alt-tags are perfect, no need of removing them :)

If I correctly understand the code the it should sanitize the alt-tag, but please double-check that before merging!

(Part of the [A11y project](https://steemit.com/steemit/@novium/steem-it-a11y-project-second-pull-request-fixing-image-alt-tags))