### PR TITLE
Category validate update

### DIFF
--- a/app/components/cards/CategorySelector.jsx
+++ b/app/components/cards/CategorySelector.jsx
@@ -78,13 +78,13 @@ export function validateCategory(category, required = true) {
     return (
         // !category || category.trim() === '' ? 'Required' :
         cats.length > 5 ? 'Please use only five categories' :
-        cats.find(c => c.length > 24)           ? 'Maximum tag length is 24 characters' :
-        cats.find(c => c.split('-').length > 2) ? 'Use only one dash' :
-        cats.find(c => c.indexOf(',') >= 0)     ? 'Use spaces to separate tags' :
-        cats.find(c => /[A-Z]/.test(c))         ? 'Use only lowercase letters' :
-        cats.find(c => !/^[a-z0-9-]+$/.test(c)) ? 'Use only lowercase letters, digits and one dash' :
-        cats.find(c => !/^[a-z]/.test(c))       ? 'Must start with a letter' :
-        cats.find(c => !/[a-z0-9]$/.test(c))    ? 'Must end with a letter or number' :
+        cats.find(c => c.length > 24)            ? 'Maximum tag length is 24 characters' :
+        cats.find(c => c.split('-').length > 2)  ? 'Use only one dash' :
+        cats.find(c => c.indexOf(',') >= 0)      ? 'Use spaces to separate tags' :
+        cats.find(c => /[A-Z]/.test(c))          ? 'Use only lowercase letters' :
+        cats.find(c => !/^[a-z0-9-#]+$/.test(c)) ? 'Use only lowercase letters, digits and one dash' :
+        cats.find(c => !/^[a-z-#]/.test(c))      ? 'Must start with a letter' :
+        cats.find(c => !/[a-z0-9]$/.test(c))     ? 'Must end with a letter or number' :
         null
     )
 }

--- a/app/components/elements/ReplyEditor.jsx
+++ b/app/components/elements/ReplyEditor.jsx
@@ -481,7 +481,7 @@ export default formId => reduxForm(
 
             if (!linkProps) throw new Error('Unknown type: ' + type)
 
-            const formCategories = Set(category ? category.split(/ +/) : [])
+            const formCategories = Set(category ? category.replace("#","").split(/ +/) : [])
             const rootCategory = originalPost && originalPost.category ?
                 originalPost.category : formCategories.first()
             const rootTag = /^[-a-z\d]+$/.test(rootCategory) ? rootCategory : null

--- a/app/components/elements/ReplyEditor.jsx
+++ b/app/components/elements/ReplyEditor.jsx
@@ -481,7 +481,7 @@ export default formId => reduxForm(
 
             if (!linkProps) throw new Error('Unknown type: ' + type)
 
-            const formCategories = Set(category ? category.replace("#","").split(/ +/) : [])
+            const formCategories = Set(category ? category.replace(/#/g,"").split(/ +/) : [])
             const rootCategory = originalPost && originalPost.category ?
                 originalPost.category : formCategories.first()
             const rootTag = /^[-a-z\d]+$/.test(rootCategory) ? rootCategory : null


### PR DESCRIPTION
Update validation to allow users who enter category tags with # hashtag when posting/editing.   Parsing is done on creation to strip hashtag symbols.   