### PR TITLE
Markup numbered lists with more than 9 items restart at "0"

### DIFF
--- a/app/assets/stylesheets/foundation-overrides.scss
+++ b/app/assets/stylesheets/foundation-overrides.scss
@@ -28,3 +28,8 @@ input[type=submit].disabled, input[type=submit].disabled:focus {
 button, .button {
   text-transform: uppercase;
 }
+
+ol, ul {
+  margin-left: 1.9rem;
+}
+


### PR DESCRIPTION
From @TimCliff's https://steemit.com/steemit-ideas/@timcliff/the-steemit-wish-list-avatars-notifications-multi-language-support-and-more-oh-my-v2-0

![image](https://cloud.githubusercontent.com/assets/22267287/19102973/dbc87202-8a88-11e6-9748-21da18ddcd88.png)

The bug was showing as

![image](https://cloud.githubusercontent.com/assets/22267287/19102991/e9ed262a-8a88-11e6-8380-a7b3db149ae5.png)

This was caused by a default normalize.css rule for the left margin on ol and ul tags.

Corrected:

![image](https://cloud.githubusercontent.com/assets/22267287/19103020/1d0b85b0-8a89-11e6-9c7f-6b8bd77c6644.png)

