### PR TITLE
Fix Witness Vote Login Prompting for Posting Key

### DIFF
--- a/app/components/modules/LoginForm.jsx
+++ b/app/components/modules/LoginForm.jsx
@@ -127,7 +127,7 @@ class LoginForm extends Component {
             'Authenticate for this transaction' :
             'Login to your Steem Account';
         const opType = loginBroadcastOperation ? loginBroadcastOperation.get('type') : null
-        const authType = /vote|comment/.test(opType) ? 'Posting' : 'Active or Owner'
+        const authType = /^vote|comment/.test(opType) ? 'Posting' : 'Active or Owner'
         const submitLabel = loginBroadcastOperation ? 'Sign' : 'Login';
         let error = password.touched && password.error ? password.error : this.props.login_error
         if (error === 'owner_login_blocked') {


### PR DESCRIPTION
This is in response to a dialog in Steemit Chat #help channel.

![image](https://cloud.githubusercontent.com/assets/22267287/19144600/6b98c040-8b5f-11e6-973b-af32f4b3b555.png)

The issue arised from the check on the authType: _vote_ was being matched in _account_witness_vote_.

Corrected:

![image](https://cloud.githubusercontent.com/assets/22267287/19144678/ccefaf20-8b5f-11e6-9331-04625923647c.png)
