### PR TITLE
Fix for External Witness URLs to Open in New

### DIFF
--- a/app/components/modules/BlocktradesDeposit.jsx
+++ b/app/components/modules/BlocktradesDeposit.jsx
@@ -222,7 +222,7 @@ export default class BlocktradesDeposit extends React.Component {
                 <div className="row">
                     <div className="column small-12">
                         {sendTo}
-                        {paymentLink && !hasError && <a href={paymentLink}>&nbsp;<Icon name="extlink" /></a>}
+                        {paymentLink && !hasError && <a href={paymentLink} target="_blank">&nbsp;<Icon name="extlink" /></a>}
                         <div className="de-empasize">{depositLimit && `Suggested limit ${depositLimit}`}&nbsp;</div>
                     </div>
                 </div>

--- a/app/components/modules/BlocktradesDeposit.jsx
+++ b/app/components/modules/BlocktradesDeposit.jsx
@@ -222,7 +222,7 @@ export default class BlocktradesDeposit extends React.Component {
                 <div className="row">
                     <div className="column small-12">
                         {sendTo}
-                        {paymentLink && !hasError && <a href={paymentLink} target="_blank">&nbsp;<Icon name="extlink" /></a>}
+                        {paymentLink && !hasError && <a href={paymentLink}>&nbsp;<Icon name="extlink" /></a>}
                         <div className="de-empasize">{depositLimit && `Suggested limit ${depositLimit}`}&nbsp;</div>
                     </div>
                 </div>

--- a/app/components/pages/Witnesses.jsx
+++ b/app/components/pages/Witnesses.jsx
@@ -1,6 +1,7 @@
 import React, {PropTypes} from 'react';
 import {connect} from 'react-redux';
 import { Link } from 'react-router';
+import links from 'app/utils/Links'
 import Icon from 'app/components/elements/Icon';
 import transaction from 'app/redux/Transaction'
 import ByteBuffer from 'bytebuffer'
@@ -50,7 +51,11 @@ class Witnesses extends React.Component {
                 (myVote === true ? ' Voting__button--upvoted' : '');
             let witness_thread = ""
             if(thread) {
-                witness_thread = <Link to={thread}>witness thread</Link>
+                if(links.remote.test(thread)) {
+                    witness_thread = <Link to={thread} target="_blank">witness thread&nbsp;<Icon name="extlink" /></Link>
+                } else {
+                    witness_thread = <Link to={thread}>witness thread</Link>
+                }
             }
             return (
                     <tr key={owner}>
@@ -102,7 +107,7 @@ class Witnesses extends React.Component {
                         <h2>Top Witnesses</h2>
                         <p>
                             <strong>You have {witness_votes_count} votes remaining.</strong>
-                            You can vote for a maximum of 30 witnesses.
+                            &nbsp;You can vote for a maximum of 30 witnesses.
                         </p>
                     </div>
                 </div>

--- a/app/components/pages/Witnesses.jsx
+++ b/app/components/pages/Witnesses.jsx
@@ -52,7 +52,7 @@ class Witnesses extends React.Component {
             let witness_thread = ""
             if(thread) {
                 if(links.remote.test(thread)) {
-                    witness_thread = <Link to={thread} target="_blank">witness thread&nbsp;<Icon name="extlink" /></Link>
+                    witness_thread = <Link to={thread}>witness thread&nbsp;<Icon name="extlink" /></Link>
                 } else {
                     witness_thread = <Link to={thread}>witness thread</Link>
                 }


### PR DESCRIPTION
Some witnesses set their url with an external links. This will allow users to view them from the Witnesses page (instead of directing to steemit.com homepage due to it not found).

In addition, added a space between the two sentences:

![image](https://cloud.githubusercontent.com/assets/22267287/19337456/3faf5870-90ca-11e6-9a9f-ed8e5bb6302b.png)

Also, added `target=_blank` to another page's link that had showed the extlink icon.
