### PR TITLE
URL regex #424

### DIFF
--- a/app/utils/Links.js
+++ b/app/utils/Links.js
@@ -1,12 +1,13 @@
 
 const urlChar = '[^\\s"\'<>\\]\\[\\(\\)]'
+const urlCharEnd = urlChar.replace(/\]$/, '.]') // insert bad chars to end on
 const imagePath = '(?:(?:\\.(?:tiff?|jpe?g|gif|png|svg|ico)|ipfs/[a-z\\d]{40,}))'
-const domainPath = '(?:[-a-zA-Z0-9\\._]+)'
-const urlChars = '(?:' + urlChar + '*)'
+const domainPath = '(?:[-a-zA-Z0-9\\._]*[-a-zA-Z0-9])'
+const urlChars = '(?:' + urlChar + '*' + urlCharEnd + ')?'
 
 const urlSet = ({domain = domainPath, path} = {}) => {
      // urlChars is everything but html or markdown stop chars
-    return `https?:\/\/${domain}(?::\\d{2,5})?(?:[/\\?#]${urlChars}${path ? path + urlChars : ''})${path ? '' : '?'}`
+    return `https?:\/\/${domain}(?::\\d{2,5})?(?:[/\\?#]${urlChars}${path ? path : ''})${path ? '' : '?'}`
 }
 
 /**

--- a/app/utils/Links.js
+++ b/app/utils/Links.js
@@ -1,6 +1,6 @@
 
 const urlChar = '[^\\s"\'<>\\]\\[\\(\\)]'
-const urlCharEnd = urlChar.replace(/\]$/, '.]') // insert bad chars to end on
+const urlCharEnd = urlChar.replace(/\]$/, '.,]') // insert bad chars to end on
 const imagePath = '(?:(?:\\.(?:tiff?|jpe?g|gif|png|svg|ico)|ipfs/[a-z\\d]{40,}))'
 const domainPath = '(?:[-a-zA-Z0-9\\._]*[-a-zA-Z0-9])'
 const urlChars = '(?:' + urlChar + '*' + urlCharEnd + ')?'

--- a/app/utils/Links.test.js
+++ b/app/utils/Links.test.js
@@ -13,6 +13,8 @@ describe('Links', () => {
         match(linksRe.any(), 'https://example.com\n', 'https://example.com')
         match(linksRe.any(), ' https://example.com ', 'https://example.com')
         match(linksRe.any(), 'https://example.com ', 'https://example.com')
+        match(linksRe.any(), 'https://example.com.', 'https://example.com')
+        match(linksRe.any(), 'https://example.com/page.', 'https://example.com/page')
     })
     it('multiple matches', () => {
         const all = linksRe.any('ig')

--- a/app/utils/Links.test.js
+++ b/app/utils/Links.test.js
@@ -15,6 +15,8 @@ describe('Links', () => {
         match(linksRe.any(), 'https://example.com ', 'https://example.com')
         match(linksRe.any(), 'https://example.com.', 'https://example.com')
         match(linksRe.any(), 'https://example.com/page.', 'https://example.com/page')
+        match(linksRe.any(), 'https://example.com,', 'https://example.com')
+        match(linksRe.any(), 'https://example.com/page,', 'https://example.com/page')
     })
     it('multiple matches', () => {
         const all = linksRe.any('ig')


### PR DESCRIPTION
 - `urlChars` must not end with  a `.` or `,`
 - `domainPath` must not end with a `\` or `.`, or `_`

Any other chars to blacklist? This is a minimal set which resolves #424 