### PR TITLE
resteemed icon falls out of metadata portion on right-hand-side #511

### DIFF
--- a/app/components/cards/PostSummary.scss
+++ b/app/components/cards/PostSummary.scss
@@ -122,7 +122,7 @@ ul.PostsList__summaries {
 
 @media screen and (min-width: 39.9375em) {
   .PostSummary.with-image .PostSummary__reblogged_by .Icon.reblog {
-    margin-left: -22px;
+    margin-left: 0px;
   }
 }
 


### PR DESCRIPTION
- adjust alignment for resteem icon to match post snippet