### PR TITLE
do not display invalid cashout_time #532

### DIFF
--- a/app/components/elements/Voting.jsx
+++ b/app/components/elements/Voting.jsx
@@ -170,7 +170,8 @@ class Voting extends React.Component {
         if(promoted > 0) {
             payoutItems.push({value: 'Promotion Cost $' + formatDecimal(promoted).join('')});
         }
-        if (cashout_active) {
+        const hide_cashout_532 = cashout_time.indexOf('1969') === 0 // tmpfix for #532
+        if (cashout_active && !hide_cashout_532) {
             payoutItems.push({value: <TimeAgoWrapper date={cashout_time} />});
         }
 


### PR DESCRIPTION
This tmpfix can be removed when https://github.com/steemit/steem/issues/546 is resolved.

It fixes the following behavior:
![](https://cloud.githubusercontent.com/assets/5168676/19943610/85e7a5e6-a10e-11e6-81e5-a9e26c15fec2.png)