### PR TITLE
simplify verbiage in not allowing multi accounts for new users, remov…

### DIFF
--- a/app/components/pages/CreateAccount.jsx
+++ b/app/components/pages/CreateAccount.jsx
@@ -198,7 +198,7 @@ class CreateAccount extends React.Component {
                 <div className="column">
                     <div className="callout alert">
                         <p>Our records indicate that you already have steem account: <strong>{existingUserAccount}</strong></p>
-                        <p>In order to prevent abuse (each registered account costs 3 STEEM) Steemit can only register one account per verified user.</p>
+                        <p>In order to prevent abuse Steemit can only register one account per verified user.</p>
                         <p>You can either <a href="/login.html">login</a> to your existing account
                             or <a href="mailto:support@steemit.com">send us email</a> if you need a new account.</p>
                     </div>


### PR DESCRIPTION
This is a simple verbiage change so we don't need to constantly updated the steem creation fee listed/or add logic to show a more dynamic value.  This message is more simplified as well for new users who might already have an established account. 