### PR TITLE
Fix joined date display

### DIFF
--- a/app/components/pages/UserProfile.scss
+++ b/app/components/pages/UserProfile.scss
@@ -119,12 +119,6 @@
 
 @media screen and (max-width: 39.9375em) {
 
-    .UserProfile__banner {
-        > div.column {
-            height: 115px;
-        }
-    }
-
     div.UserProfile__top-nav .menu li>a {
         padding: 8px;
     }


### PR DESCRIPTION
For issue #624

With a small browser width like those on mobile, the Joined Date is displayed as follows:

![image](https://cloud.githubusercontent.com/assets/22267287/20298289/eb1210e0-aac9-11e6-9e4b-ebe28fccb0e4.png)
After fix:

![image](https://cloud.githubusercontent.com/assets/22267287/20298302/fbc98ca6-aac9-11e6-8965-74b73acd5d18.png)

A CSS rule from before the user pics were implemented needed to be removed. In the past, this was to shrink the banner div as the h2 was responsively shrunk too.