### PR TITLE
add support for renamed API key, with backwards compatibility

### DIFF
--- a/app/components/pages/UserProfile.jsx
+++ b/app/components/pages/UserProfile.jsx
@@ -170,11 +170,11 @@ export default class UserProfile extends React.Component {
         else if( section === 'comments' && account.post_history ) {
            // NOTE: `posts` key will be renamed to `comments` (https://github.com/steemit/steem/issues/507)
            //   -- see also GlobalReducer.js
-           if( account.posts )
+           if( account.posts || account.comments )
            {
               tab_content = <PostsList
                   emptyText={translate('user_hasnt_made_any_posts_yet', {name})}
-                  posts={account.posts}
+                  posts={account.posts || account.comments}
                   loading={fetching}
                   category="comments"
                   loadMore={this.loadMore}

--- a/app/redux/GlobalReducer.js
+++ b/app/redux/GlobalReducer.js
@@ -154,7 +154,8 @@ export default createModule({
                 if (order === 'by_author' || order === 'by_feed' || order === 'by_comments' || order === 'by_replies') {
                     // category is either "blog", "feed", "comments", or "recent_replies" (respectively) -- and all posts are keyed under current profile
                     // one exception: "comments" category is keyed as "posts" in get_state (https://github.com/steemit/steem/issues/507)
-                    const key = ['accounts', accountname, category == "comments" ? "posts" : category]
+                    const _legacy_compat = state.getIn(['accounts', accountname]).has("posts") //TODO: remove after switching to shared-db
+                    const key = ['accounts', accountname, (_legacy_compat && category == "comments") ? "posts" : category]
                     new_state = state.updateIn(key, List(), list => {
                         return list.withMutations(posts => {
                             data.forEach(value => {


### PR DESCRIPTION
Relevant backend change: https://github.com/steemit/steem/commit/b7328bb0161b1efb97a8ab9e0798344f4114f272

This allows us to test steem/develop while maintaining compatibility with steem/master.