### PR TITLE
fix clicking label to hide dropdown

### DIFF
--- a/app/components/elements/DropdownMenu.jsx
+++ b/app/components/elements/DropdownMenu.jsx
@@ -71,7 +71,7 @@ export default class DropdownMenu extends React.Component {
                 {hasDropdown && <Icon name="dropdown-arrow" />}
             </span>
 
-        if(hasDropdown) entry = <a key="entry" href={href || '#'} onClick={this.toggle}>{entry}</a>
+        if(hasDropdown) entry = <a key="entry" href={href || '#'} onMouseDown={this.toggle}>{entry}</a>
 
         const menu = <VerticalMenu key="menu" title={title} items={items} hideValue={selected} className="VerticalMenu" />;
         const cls = 'DropdownMenu' + (this.state.shown ? ' show' : '') + (className ? ` ${className}` : '')


### PR DESCRIPTION
Currently when a user clicks a dropdown label (e.g. `3 votes`) to open the menu, then clicks it again, it cancels out the hide event. This restores the expected behavior.