### PR TITLE
Fix follow loading status, and invert shared-db follows api fix

### DIFF
--- a/app/components/elements/Follow.jsx
+++ b/app/components/elements/Follow.jsx
@@ -46,6 +46,7 @@ export default class Follow extends React.Component {
         this.ignore = () => follow(follower, following, Set(['ignore']))
         this.unignore = () => follow(follower, following, Set())
     }
+
     render() {
         const {follower, following, what, showFollow, showMute, fat, children} = this.props // html
         const {existingFollows, loading} = this.props // redux
@@ -71,6 +72,7 @@ export default class Follow extends React.Component {
         </span>
     }
 }
+
 const emptyMap = Map()
 const emptySet = Set()
 module.exports = connect(
@@ -82,7 +84,7 @@ module.exports = connect(
             follower = current_user ? current_user.get('username') : null
         }
         const f = state.global.getIn(['follow', 'get_following', follower], emptyMap)
-        const loading = f.get('loading')
+        const loading = f.getIn(['blog', 'loading'], false) || f.getIn(['ignore', 'loading'], false)
         const existingFollows = Set(f.getIn(['result', following], emptySet))// Convert List to Set
         return {
             follower,

--- a/app/components/elements/UserList.jsx
+++ b/app/components/elements/UserList.jsx
@@ -29,9 +29,7 @@ class UserList extends React.Component {
         const title = this.props.title
 
         let user_list = users.map((item, index) => {
-            // TODO: remove this check after shared-db upgrade. https://github.com/steemit/steem/pull/577
-            if((typeof item) !== 'string') item = item.get(0);
-            if(item === "blog") {
+            if(item.get(0) === "blog") {
                 return <UserListRow account={account} user={index} key={index} />
             }
             return null;

--- a/app/components/pages/UserProfile.jsx
+++ b/app/components/pages/UserProfile.jsx
@@ -90,9 +90,7 @@ export default class UserProfile extends React.Component {
             const followers_loaded = status_followers.get('loading') === false && status_followers.get('error') == null
             if (followers_loaded) {
                 followerCount = followers.get('result').filter(a => {
-                    // TODO: remove this check after shared-db upgrade. https://github.com/steemit/steem/pull/577
-                    if((typeof a) !== 'string') a = a.get(0);
-                    return a === "blog";
+                    return a.get(0) === "blog";
                 }).size;
             }
         }
@@ -102,9 +100,7 @@ export default class UserProfile extends React.Component {
             const following_loaded = status_following.get('loading') === false && status_following.get('error') == null
             if (following_loaded) {
                 followingCount = following.get('result').filter(a => {
-                    // TODO: remove this check after shared-db upgrade. https://github.com/steemit/steem/pull/577
-                    if((typeof a) !== 'string') a = a.get(0);
-                    return a === "blog";
+                    return a.get(0) === "blog";
                 }).size;
             }
         }

--- a/app/redux/FollowSaga.js
+++ b/app/redux/FollowSaga.js
@@ -1,6 +1,7 @@
 import {fromJS, Map} from 'immutable'
 import {call, put} from 'redux-saga/effects';
 import {Apis} from 'shared/api_client';
+import {List} from 'immutable'
 
 // Test limit with 2 (not 1, infinate looping)
 export function* loadFollows(method, follower, type, start = '', limit = 100) {
@@ -17,7 +18,8 @@ export function* loadFollows(method, follower, type, start = '', limit = 100) {
             m = m.update('result', Map(), m2 => {
                 res.forEach(value => {
                     cnt++
-                    const what = value.get('what')
+                    let what = value.get('what')
+                    if(typeof what === 'string') what = new List([what]) // TODO: after shared-db upgrade, this line can be removed
                     const following = lastFollowing = value.get(key)
                     m2 = m2.set(following, what)
                 })


### PR DESCRIPTION
1) `loading` prop was broken in `app/components/elements/Follow.jsx`, causing "Follow" and "Mute" to never show up for user dropdowns
2) revert shared-db follows api compat logic
3) force-convert incoming `what` strings back to Lists. steemd API will revert back to the old format after rc1.