### PR TITLE
switch to using onclick, remove menu close event. resolves #722

### DIFF
--- a/app/components/elements/DropdownMenu.jsx
+++ b/app/components/elements/DropdownMenu.jsx
@@ -24,7 +24,7 @@ export default class DropdownMenu extends React.Component {
     }
 
     componentWillUnmount() {
-        document.removeEventListener('mousedown', this.hide);
+        document.removeEventListener('click', this.hide);
     }
 
     toggle = (e) => {
@@ -36,7 +36,7 @@ export default class DropdownMenu extends React.Component {
     show = (e) => {
         e.preventDefault();
         this.setState({shown: true});
-        document.addEventListener('mousedown', this.hide);
+        document.addEventListener('click', this.hide);
     };
 
     hide = (e) => {
@@ -44,8 +44,9 @@ export default class DropdownMenu extends React.Component {
         const inside_dropdown = !!findParent(e.target, 'VerticalMenu');
         if (inside_dropdown) return;
 
+        e.preventDefault()
         this.setState({shown: false});
-        document.removeEventListener('mousedown', this.hide);
+        document.removeEventListener('click', this.hide);
     };
 
     navigate = (e) => {
@@ -71,7 +72,7 @@ export default class DropdownMenu extends React.Component {
                 {hasDropdown && <Icon name="dropdown-arrow" />}
             </span>
 
-        if(hasDropdown) entry = <a key="entry" href={href || '#'} onMouseDown={this.toggle} onClick={e => {e.preventDefault()}}>{entry}</a>
+        if(hasDropdown) entry = <a key="entry" href={href || '#'} onClick={this.toggle}>{entry}</a>
 
         const menu = <VerticalMenu key="menu" title={title} items={items} hideValue={selected} className="VerticalMenu" />;
         const cls = 'DropdownMenu' + (this.state.shown ? ' show' : '') + (className ? ` ${className}` : '')

--- a/app/components/elements/VerticalMenu.jsx
+++ b/app/components/elements/VerticalMenu.jsx
@@ -13,13 +13,21 @@ export default class VerticalMenu extends React.Component {
         ]),
     };
 
+    closeMenu = (e) => {
+        // If this was not a left click, or if CTRL or CMD were held, do not close the menu.
+        if(e.button !== 0 || e.ctrlKey || e.metaKey) return;
+
+        // Simulate clicking of document body which will close any open menus
+        document.body.click();
+    }
+
     render() {
         const {items, title, className, hideValue} = this.props;
         return <ul className={'VerticalMenu menu vertical' + (className ? ' ' + className : '')}>
             {title && <li className="title">{title}</li>}
             {items.map(i => {
                 if(i.value === hideValue) return null
-                return <li key={i.value}>
+                return <li key={i.value} onClick={this.closeMenu}>
                     {i.link ? <Link to={i.link} onClick={i.onClick}>
                         {i.icon && <Icon name={i.icon} />}{i.label ? i.label : i.value}
                         &nbsp; {i.addon}

--- a/app/components/elements/VerticalMenu.jsx
+++ b/app/components/elements/VerticalMenu.jsx
@@ -13,17 +13,13 @@ export default class VerticalMenu extends React.Component {
         ]),
     };
 
-    closeMenu = () => {
-        document.body.click();
-    }
-
     render() {
         const {items, title, className, hideValue} = this.props;
         return <ul className={'VerticalMenu menu vertical' + (className ? ' ' + className : '')}>
             {title && <li className="title">{title}</li>}
             {items.map(i => {
                 if(i.value === hideValue) return null
-                return <li key={i.value} onClick={this.closeMenu}>
+                return <li key={i.value}>
                     {i.link ? <Link to={i.link} onClick={i.onClick}>
                         {i.icon && <Icon name={i.icon} />}{i.label ? i.label : i.value}
                         &nbsp; {i.addon}


### PR DESCRIPTION
mousedown was used for the #641 fix because of an onClick conflict.

It appears the conflict was due to `closeMenu` in `VerticalMenu` -- as far as I can tell, we do not need this logic.