### PR TITLE
Remove account from market state, use SagaShared getAccount to fetch …

### DIFF
--- a/app/components/pages/Market.jsx
+++ b/app/components/pages/Market.jsx
@@ -530,15 +530,18 @@ class Market extends React.Component {
 const DEFAULT_EXPIRE = 0xFFFFFFFF//Math.floor((Date.now() / 1000) + (60 * 60 * 24)) // 24 hours
 module.exports = {
     path: 'market',
-    component: connect(state => ({
-        orderbook:   state.market.get('orderbook'),
-        open_orders: process.env.BROWSER ? state.market.get('open_orders') : [],
-        ticker:      state.market.get('ticker'),
-        account:     state.market.get('account'),
-        history:     state.market.get('history'),
-        user:        state.user.get('current') ? state.user.get('current').get('username') : null,
-        feed:        state.global.get('feed_price').toJS()
-    }),
+    component: connect(state => {
+        const username = state.user.get('current') ? state.user.get('current').get('username') : null;
+        return {
+            orderbook:   state.market.get('orderbook'),
+            open_orders: process.env.BROWSER ? state.market.get('open_orders') : [],
+            ticker:      state.market.get('ticker'),
+            account:     state.global.getIn(['accounts', username]),
+            history:     state.market.get('history'),
+            user:        username,
+            feed:        state.global.get('feed_price').toJS()
+        }
+    },
     dispatch => ({
         notify: (message) => {
             dispatch({type: 'ADD_NOTIFICATION', payload:

--- a/app/redux/AuthSaga.js
+++ b/app/redux/AuthSaga.js
@@ -4,7 +4,7 @@ import Apis from 'shared/api_client/ApiInstances'
 import {Set, Map, fromJS, List} from 'immutable'
 import {PrivateKey} from 'shared/ecc'
 import user from 'app/redux/User'
-import g from 'app/redux/GlobalReducer'
+import {getAccount} from 'app/redux/SagaShared'
 
 // operations that require only posting authority
 const postingOps = Set(`vote, comment, delete_comment, custom_json`.trim().split(/,\s*/))
@@ -113,13 +113,9 @@ export function* findSigningKey({opType, username, password}) {
 
     const private_keys = currentUsername === username ? currentUser.get('private_keys') : Map()
 
-    let account = yield select(state => state.global.getIn(['accounts', username]))
-    if (!account) {
-        [account] = yield call(Apis.db_api, 'get_accounts', [username])
-        if (!account) throw new Error('Account not found')
-        account = fromJS(account)
-        yield put(g.actions.receiveAccount({account}))
-    }
+    const account = yield call(getAccount, username);
+    if (!account) throw new Error('Account not found')
+
     for (const authType of authTypes) {
         let private_key
         if (password) {

--- a/app/redux/GlobalReducer.js
+++ b/app/redux/GlobalReducer.js
@@ -23,7 +23,6 @@ export default createModule({
         {
             action: 'RECEIVE_STATE',
             reducer: (state, action) => {
-                // console.log('RECEIVE_STATE', action, state.toJS());
                 let payload = fromJS(action.payload)
                 if(payload.has('content')) {
                     const content = payload.get('content').withMutations(c => {

--- a/app/redux/MarketReducer.js
+++ b/app/redux/MarketReducer.js
@@ -1,10 +1,6 @@
-import {Map, Set, List, fromJS, Iterable} from 'immutable';
+import {Map} from 'immutable';
 import createModule from 'redux-modules';
-import {PropTypes} from 'react';
-import {emptyContent} from 'app/redux/EmptyState';
-import constants from './constants';
 
-const {string, object, bool, array, oneOf, oneOfType, func, any} = PropTypes
 
 export default createModule({
     name: 'market',
@@ -39,12 +35,6 @@ export default createModule({
             reducer: (state, action) => {
                 return state.set('history', [...action.payload, ...state.get('history')]);
             }
-        },
-        {
-            action: 'RECEIVE_ACCOUNT',
-            reducer: (state, action) => {
-                return state.set('account', action.payload.account);
-            }
-        },
+        }
     ]
 });

--- a/app/redux/MarketSaga.js
+++ b/app/redux/MarketSaga.js
@@ -2,9 +2,7 @@ import {takeLatest} from 'redux-saga';
 import {call, put} from 'redux-saga/effects';
 import Apis from 'shared/api_client/ApiInstances';
 import MarketReducer from './MarketReducer';
-import g from 'app/redux/GlobalReducer'
-// import constants from './constants';
-import {fromJS} from 'immutable'
+import {getAccount} from './SagaShared';
 
 export const marketWatches = [watchLocationChange, watchUserLogin, watchMarketUpdate];
 
@@ -68,13 +66,7 @@ export function* fetchOpenOrders(set_user_action) {
         const db_api = Apis.instance().db_api;
         const state = yield call([db_api, db_api.exec], 'get_open_orders', [username]);
         yield put(MarketReducer.actions.receiveOpenOrders(state));
-
-       let [account] = yield call(Apis.db_api, 'get_accounts', [username])
-       if(account) {
-           account = fromJS(account)
-           yield put(MarketReducer.actions.receiveAccount({ account }))
-           yield put(g.actions.receiveAccount({ account })) // TODO: move out of MarketSaga. See notes in #741
-       }
+        yield call(getAccount, username, true);
     } catch (error) {
         console.error('~~ Saga fetchOpenOrders error ~~>', error);
         yield put({type: 'global/STEEM_API_ERROR', error: error.message});


### PR DESCRIPTION
…accounts #437

In my previous commit for #437 I added the global reducer to MarketSaga but @roadscape mentioned this was not really desirable so I decided to refactor it again. I noticed the market state was keeping a duplicate of the account object that could just as easily be pulled from state.global.accounts so Market.jsx now uses that account object instead.

Also, SagaShared has a getAccount method but AuthSaga and MarketSaga was duplicating that method so I replaced them with the shared method.