### PR TITLE
Login form transfer updates

### DIFF
--- a/app/components/modules/LoginForm.jsx
+++ b/app/components/modules/LoginForm.jsx
@@ -1,6 +1,5 @@
 /* eslint react/prop-types: 0 */
 import React, { PropTypes, Component } from 'react';
-import ReactDOM from 'react-dom';
 import {PublicKey, PrivateKey} from 'shared/ecc'
 import transaction from 'app/redux/Transaction'
 import g from 'app/redux/GlobalReducer'
@@ -50,15 +49,9 @@ class LoginForm extends Component {
         this.initForm(props)
     }
 
-    componentWillMount() {
-        // Use username.value as the defult (input types should not contain both value and defaultValue)
-        const username = {...this.state.username}
-        username.value = this.props.initialUsername
-        this.setState({username})
-    }
-
     componentDidMount() {
-        if (this.refs.username) ReactDOM.findDOMNode(this.refs.username).focus()
+        if (this.refs.username && !this.refs.username.value) this.refs.username.focus();
+        if (this.refs.username && this.refs.username.value) this.refs.pw.focus();
     }
 
     shouldComponentUpdate = shouldComponentUpdate(this, 'LoginForm')
@@ -168,11 +161,13 @@ class LoginForm extends Component {
                 onChange={this.props.clearError}
                 method="post"
             >
-                <div>
-                    <input type="text" required placeholder="Enter your username" ref="username"
-                        {...username.props} onChange={usernameOnChange} autoComplete="on" disabled={submitting} />
-                    <div className="error">{username.touched && username.blur && username.error}&nbsp;</div>
+                <div className="input-group">
+                    <span className="input-group-label">@</span>
+                    <input className="input-group-field" type="text" required placeholder="Enter your username" ref="username"
+                        {...username.props} onChange={usernameOnChange} autoComplete="on" disabled={submitting}
+                    />
                 </div>
+                {username.touched && username.blur && username.error ? <div className="error">{username.error}&nbsp;</div> : null}
 
                 <div>
                     <input type="password" required ref="pw" placeholder="Password or WIF" {...password.props} autoComplete="on" disabled={submitting} />
@@ -251,12 +246,13 @@ export default connect(
         }
 
         // The username input has a value prop, so it should not use initialValues
-         const initialUsername = currentUser && currentUser.has('username') ? currentUser.get('username') : urlAccountName()
-
+        const initialUsername = currentUser && currentUser.has('username') ? currentUser.get('username') : urlAccountName()
         const loginDefault = state.user.get('loginDefault')
         if(loginDefault) {
             const {username, authType} = loginDefault.toJS()
             if(username && authType) initialValues.username = username + '/' + authType
+        } else if (initialUsername) {
+            initialValues.username = initialUsername;
         }
         let msg = '';
         const msg_match = window.location.hash.match(/msg\=([\w]+)/);

--- a/app/components/modules/Transfer.jsx
+++ b/app/components/modules/Transfer.jsx
@@ -151,7 +151,7 @@ class TransferForm extends Component {
                 <div className="row">
                     <div className="column small-2" style={{paddingTop: 5}}>From</div>
                     <div className="column small-10">
-                        <div className="input-group">
+                        <div className="input-group" style={{marginBottom: "1.25rem"}}>
                             <span className="input-group-label">@</span>
                             <input
                                 className="input-group-field bold"
@@ -163,12 +163,10 @@ class TransferForm extends Component {
                     </div>
                 </div>
 
-                <br />
-
                 {advanced && <div className="row">
                     <div className="column small-2" style={{paddingTop: 5}}>To</div>
                     <div className="column small-10">
-                        <div className="input-group">
+                        <div className="input-group" style={{marginBottom: "1.25rem"}}>
                             <span className="input-group-label">@</span>
                             <input
                                 className="input-group-field"
@@ -191,7 +189,7 @@ class TransferForm extends Component {
                 <div className="row">
                     <div className="column small-2" style={{paddingTop: 5}}>Amount</div>
                     <div className="column small-10">
-                        <div className="input-group">
+                        <div className="input-group" style={{marginBottom: 5}}>
                             <input type="text" placeholder="Amount" {...amount.props} ref="amount" autoComplete="off" disabled={loading} />
                             {asset && <span className="input-group-label" style={{paddingLeft: 0, paddingRight: 0}}>
                                 <select {...asset.props} placeholder="Asset" disabled={loading} style={{minWidth: "5rem", height: "inherit", backgroundColor: "transparent", border: "none"}}>
@@ -200,9 +198,10 @@ class TransferForm extends Component {
                                 </select>
                             </span>}
                         </div>
-                        <AssetBalance balanceValue={this.balanceValue()} onClick={this.assetBalanceClick} />
-
-                        {(asset && asset.touched) || (amount.touched && amount.error && asset.error) ?
+                        <div style={{marginBottom: "0.6rem"}}>
+                            <AssetBalance balanceValue={this.balanceValue()} onClick={this.assetBalanceClick} />
+                        </div>
+                        {(asset && asset.touched && asset.error ) || (amount.touched && amount.error) ?
                         <div className="error">
                             {asset && asset.touched && asset.error && asset.error}&nbsp;
                             {amount.touched && amount.error && amount.error}&nbsp;

--- a/app/components/modules/Transfer.jsx
+++ b/app/components/modules/Transfer.jsx
@@ -149,19 +149,38 @@ class TransferForm extends Component {
                 </div>}
 
                 <div className="row">
-                    <div className="column small-2">From</div>
+                    <div className="column small-2" style={{paddingTop: 5}}>From</div>
                     <div className="column small-10">
-                        <b>{currentUser.get('username')}</b>
+                        <div className="input-group">
+                            <span className="input-group-label">@</span>
+                            <input
+                                className="input-group-field bold"
+                                type="text"
+                                disabled
+                                value={currentUser.get('username')}
+                            />
+                        </div>
                     </div>
                 </div>
 
                 <br />
 
                 {advanced && <div className="row">
-                    <div className="column small-2">To</div>
+                    <div className="column small-2" style={{paddingTop: 5}}>To</div>
                     <div className="column small-10">
-                        <input type="text" placeholder="Send to account" {...to.props}
-                            onChange={this.onChangeTo} ref="to" autoComplete="off" disabled={loading} />
+                        <div className="input-group">
+                            <span className="input-group-label">@</span>
+                            <input
+                                className="input-group-field"
+                                ref="to"
+                                type="text"
+                                placeholder="Send to account"
+                                onChange={this.onChangeTo}
+                                autoComplete="off"
+                                disabled={loading}
+                                {...to.props}
+                            />
+                        </div>
                         {to.touched && to.blur && to.error ?
                             <div className="error">{to.error}&nbsp;</div> :
                             <p>{toVesting && powerTip3}</p>
@@ -170,24 +189,29 @@ class TransferForm extends Component {
                 </div>}
 
                 <div className="row">
-                    <div className="column small-2">Amount</div>
+                    <div className="column small-2" style={{paddingTop: 5}}>Amount</div>
                     <div className="column small-10">
-                        {asset && <span>
-                            <select {...asset.props} placeholder="Asset" disabled={loading}>
-                                <option></option>
-                                <option value="STEEM">STEEM</option>
-                                <option value="SBD">SBD</option>
-                            </select>
-                        </span>}
+                        <div className="input-group">
+                            <input type="text" placeholder="Amount" {...amount.props} ref="amount" autoComplete="off" disabled={loading} />
+                            {asset && <span className="input-group-label" style={{paddingLeft: 0, paddingRight: 0}}>
+                                <select {...asset.props} placeholder="Asset" disabled={loading} style={{minWidth: "5rem", height: "inherit", backgroundColor: "transparent", border: "none"}}>
+                                    <option value="STEEM">STEEM</option>
+                                    <option value="SBD">SBD</option>
+                                </select>
+                            </span>}
+                        </div>
                         <AssetBalance balanceValue={this.balanceValue()} onClick={this.assetBalanceClick} />
-                        <div className="error">{asset && asset.touched && asset.error && asset.error}&nbsp;</div>
-                        <input type="text" placeholder="Amount" {...amount.props} ref="amount" autoComplete="off" disabled={loading} />
-                        <div className="error">{amount.touched && amount.error && amount.error}&nbsp;</div>
+
+                        {(asset && asset.touched) || (amount.touched && amount.error && asset.error) ?
+                        <div className="error">
+                            {asset && asset.touched && asset.error && asset.error}&nbsp;
+                            {amount.touched && amount.error && amount.error}&nbsp;
+                        </div> : null}
                     </div>
                 </div>
 
                 {memo && <div className="row">
-                    <div className="column small-2">Memo</div>
+                    <div className="column small-2" style={{paddingTop: 33}}>Memo</div>
                     <div className="column small-10">
                         <small>This Memo is {isMemoPrivate ? 'Private' : 'Public'}</small>
                         <input type="text" placeholder="Memo" {...memo.props}


### PR DESCRIPTION

![image](https://cloud.githubusercontent.com/assets/6890015/20948098/3b2da00e-bbe0-11e6-9fd6-1011311ff39c.png)


@valzav asked me to add the @ prefixes to account inputs and I noticed there was room for improvement in the asset selection dropdown so I restyled it in the same vein.

The LoginForm would not set the initial value for the account for users logging in with private keys, so I've added that to the connect method initialisation. The account input also gets an @ prefix.