### PR TITLE
clarify power down error message #665

### DIFF
--- a/app/redux/Transaction.js
+++ b/app/redux/Transaction.js
@@ -70,8 +70,8 @@ export default createModule({
                         }
                         break
                     case 'withdraw_vesting':
-                        if(/Account registered by another account requires 10x account creation fee worth of Steem Power before it can power down/.test(errorStr))
-                            errorKey = 'Account registered by another account requires 10x account creation fee worth of Steem Power before it can power down'
+                        if(/Account registered by another account requires 10x account creation fee worth of Steem Power/.test(errorStr))
+                            errorKey = 'Account requires 10x the account creation fee in Steem Power (approximately 300 SP) before it can power down.'
                         break
                     default:
                         break


### PR DESCRIPTION
changes the message from

> Account registered by another account requires 10x account creation fee worth of Steem Power before it can be powered down.

to

> Account requires 10x the account creation fee in Steem Power (approximately 300 SP) before it can power down.

Now that SP is more stable the account creation fee should not fluctuate so much. Once https://github.com/steemit/steem/issues/695 is implemented, we will have the exact value in the message.