### PR TITLE
ability to sort comments by upvotes #808

### DIFF
--- a/app/components/cards/Comment.jsx
+++ b/app/components/cards/Comment.jsx
@@ -22,29 +22,12 @@ export function sortComments( cont, comments, sort_order ) {
 
   let sort_orders = {
   /** sort replies by active */
-      active: (a,b) => {
+      votes: (a,b) => {
                 let acontent = cont.get(a);
                 let bcontent = cont.get(b);
-                if (netNegative(acontent)) {
-                    return 1;
-                } else if (netNegative(bcontent)) {
-                    return -1;
-                }
-                let aactive = Date.parse( acontent.get('active') );
-                let bactive = Date.parse( bcontent.get('active') );
+                let aactive = acontent.get('active_votes').size;
+                let bactive = bcontent.get('active_votes').size;
                 return bactive - aactive;
-              },
-      update: (a,b) => {
-                let acontent = cont.get(a);
-                let bcontent = cont.get(b);
-                if (netNegative(acontent)) {
-                    return 1;
-                } else if (netNegative(bcontent)) {
-                    return -1;
-                }
-                let aactive = Date.parse( acontent.get('last_update') );
-                let bactive = Date.parse( bcontent.get('last_update') );
-                return bactive.getTime() - aactive.getTime();
               },
       new:  (a,b) =>  {
                 let acontent = cont.get(a);
@@ -84,7 +67,7 @@ class CommentImpl extends React.Component {
         // html props
         cont: React.PropTypes.object.isRequired,
         content: React.PropTypes.string.isRequired,
-        sort_order: React.PropTypes.oneOf(['active', 'updated', 'new', 'trending']).isRequired,
+        sort_order: React.PropTypes.oneOf(['votes', 'new', 'trending']).isRequired,
         root: React.PropTypes.bool,
         showNegativeComments: React.PropTypes.bool,
         onHide: React.PropTypes.func,

--- a/app/components/pages/Post.jsx
+++ b/app/components/pages/Post.jsx
@@ -143,8 +143,8 @@ class Post extends React.Component {
         );
 
 
-        let sort_orders = [ 'trending', 'active', 'new', 'updated' ];
-        let sort_labels = [ translate('trending'), translate('active'), translate('new'), translate('updated') ];
+        let sort_orders = [ 'trending', 'votes', 'new'];
+        let sort_labels = [ translate('trending'), translate('votes'), translate('new') ];
         let sort_menu = [];
 
         let selflink = `/${dis.get('category')}/@${post}`;


### PR DESCRIPTION
 - added ability to sort comment by upvotes
 - remove `updated` and `active` comment sort orders (anyone see a reason to keep them?)