### PR TITLE
914 user thumbnails

### DIFF
--- a/app/components/elements/Userpic.jsx
+++ b/app/components/elements/Userpic.jsx
@@ -20,7 +20,7 @@ class Userpic extends Component {
         } catch (e) {}
 
         if (url && /^(https?:)\/\//.test(url)) {
-            const size = width && width > 48 ? '320x320' : '90x90';
+            const size = width && width > 48 ? '320x320' : '120x120';
             url = $STM_Config.img_proxy_prefix + size + '/' + url;
         } else {
             if(hideIfDefault) {

--- a/app/components/elements/Userpic.jsx
+++ b/app/components/elements/Userpic.jsx
@@ -20,7 +20,7 @@ class Userpic extends Component {
         } catch (e) {}
 
         if (url && /^(https?:)\/\//.test(url)) {
-            const size = width && width > 48 ? '320x320' : '72x72'
+            const size = width && width > 48 ? '320x320' : '90x90';
             url = $STM_Config.img_proxy_prefix + size + '/' + url;
         } else {
             if(hideIfDefault) {


### PR DESCRIPTION
<img width="258" alt="screen shot 2017-01-02 at 2 29 54 pm" src="https://cloud.githubusercontent.com/assets/1158463/21595320/c9a2bcd2-d0fa-11e6-8328-36d9df031f06.png">
 Comment thumbnails(and also profile page thumnail) now match sharpness of profile snippet image quality on retina and 4k displays.

New example below:  
<img width="281" alt="screen shot 2017-01-02 at 2 28 58 pm" src="https://cloud.githubusercontent.com/assets/1158463/21595329/e0576c52-d0fa-11e6-9a1a-90e084ef9818.png">
