### PR TITLE
Add 3x support for thumbnail previews for post previews to remove fuz…

### DIFF
--- a/app/components/cards/PostSummary.jsx
+++ b/app/components/cards/PostSummary.jsx
@@ -149,7 +149,7 @@ class PostSummary extends React.Component {
         let thumb = null;
         if(pictures && p.image_link) {
           const prox = $STM_Config.img_proxy_prefix
-          const size = (thumbSize == 'mobile') ? '640x480' : '128x256'
+          const size = (thumbSize == 'mobile') ? '640x480' : '256x384';
           const url = (prox ? prox + size + '/' : '') + p.image_link
           if(thumbSize == 'mobile') {
             thumb = <a href={p.link} onClick={e => navigate(e, onClick, post, p.link)} className="PostSummary__image-mobile"><img src={url} /></a>


### PR DESCRIPTION
…zy display

No longer "fuzzy" post thumbnail previews up to 5K displays.  Preview below. 
<img width="226" alt="screen shot 2017-01-03 at 2 34 14 pm" src="https://cloud.githubusercontent.com/assets/1158463/21620430/467d84a4-d1c2-11e6-8607-73f9d07398e4.png">
<img width="242" alt="screen shot 2017-01-03 at 2 34 16 pm" src="https://cloud.githubusercontent.com/assets/1158463/21620434/4ab66fae-d1c2-11e6-8cf8-c22fe85fddd4.png">

