### PR TITLE
restore thumb ratio for crops #940

### DIFF
--- a/app/components/cards/PostSummary.jsx
+++ b/app/components/cards/PostSummary.jsx
@@ -149,7 +149,7 @@ class PostSummary extends React.Component {
         let thumb = null;
         if(pictures && p.image_link) {
           const prox = $STM_Config.img_proxy_prefix
-          const size = (thumbSize == 'mobile') ? '640x480' : '256x384';
+          const size = (thumbSize == 'mobile') ? '640x480' : '256x512';
           const url = (prox ? prox + size + '/' : '') + p.image_link
           if(thumbSize == 'mobile') {
             thumb = <a href={p.link} onClick={e => navigate(e, onClick, post, p.link)} className="PostSummary__image-mobile"><img src={url} /></a>


### PR DESCRIPTION
Reference: https://github.com/steemit/steemit.com/pull/940/files

The crop bounds was 2:1 for thumbnails to account for cases of tall images. The current CSS-based cropping attempts to fit images widthwise -- when the bounding box is more of a square, tall images become very low res and in some cases stretched out.

@mcifani the example image URLs you listed all had a height that was less than 2x the width, so there is no difference in the generated image. But it does make an important difference for images which do not fit this case.