### PR TITLE
Allow for comments to render voter list, unify post/comment footer vo…

### DIFF
--- a/app/components/cards/PostSummary.jsx
+++ b/app/components/cards/PostSummary.jsx
@@ -125,7 +125,7 @@ class PostSummary extends React.Component {
         </span>
 
         const content_footer = <div className="PostSummary__footer">
-            <Voting post={post} showList={false} />
+            <Voting post={post} showList={true} />
             <VotesAndComments post={post} commentsLink={comments_link} />
             <span className="PostSummary__time_author_category">
                 {!archived && <Reblog author={p.author} permlink={p.permlink} />}

--- a/app/components/elements/VotesAndComments.jsx
+++ b/app/components/elements/VotesAndComments.jsx
@@ -32,9 +32,6 @@ class VotesAndComments extends React.Component {
 
         return (
             <span className="VotesAndComments">
-                <span className="VotesAndComments__votes" title={translate('vote_count', {voteCount: voters_count})}>
-                    <Icon name={voters_count > 1 ? 'voters' : 'voter'} />&nbsp;{voters_count}
-                </span>
                 <span className={'VotesAndComments__comments' + (comments === 0 ? ' no-comments' : '')}>
                      <Link to={commentsLink} title={comments_tooltip}>
                         <Icon name={comments > 1 ? 'chatboxes' : 'chatbox'} />&nbsp;{comments}

--- a/app/components/elements/VotesAndComments.scss
+++ b/app/components/elements/VotesAndComments.scss
@@ -14,6 +14,8 @@
 }
 
 .VotesAndComments__comments {
+  margin-left: .5rem;
+  border-left: 1px solid $medium-gray;
   padding-left: 1rem;
 }
 

--- a/app/components/elements/Voting.jsx
+++ b/app/components/elements/Voting.jsx
@@ -207,7 +207,7 @@ class Voting extends React.Component {
         if (count > MAX_VOTES_DISPLAY) voters.push({value: <span>&hellip; and {(count - MAX_VOTES_DISPLAY)} more</span>});
 
         let voters_list = null;
-        if (showList && count > 0) {
+        if (showList) {
             voters_list = <DropdownMenu selected={pluralize('votes', count, true)} className="Voting__voters_list" items={voters} el="div" />;
         }
 


### PR DESCRIPTION
…te list

PR fixes #439. Also seemingly for best UI practice this also adds uniformity in all the preview footer area(payout amount, vote number(with list)).  Few changes to review: 

1.  All post previews snippets have consistent style/UI footer.  Payout amount and voter list dropdown.
2. Prior 0 votes no indicator was rendered/now indicated with "0 votes". 

Before/after

<img width="935" alt="screen shot 2017-01-09 at 5 21 27 pm" src="https://cloud.githubusercontent.com/assets/1158463/21786123/8486c63e-d690-11e6-9c60-e58a3652e7d7.png">
<img width="945" alt="screen shot 2017-01-09 at 5 24 54 pm" src="https://cloud.githubusercontent.com/assets/1158463/21786141/97b521ec-d690-11e6-989d-96516248aa75.png">




