### PR TITLE
988 revamped profile meta

### DIFF
--- a/app/components/modules/Header.jsx
+++ b/app/components/modules/Header.jsx
@@ -113,7 +113,7 @@ class Header extends React.Component {
             page_title = `Stolen Account Recovery`;
         } else if (route.page === 'UserProfile') {
             user_name = route.params[0].slice(1);
-            page_title = user_name;
+            page_title = ` @${user_name}`;
             if(route.params[1] === "followers"){
                 page_title = `People following ${user_name} `;
             }

--- a/app/components/modules/Header.jsx
+++ b/app/components/modules/Header.jsx
@@ -7,6 +7,7 @@ import resolveRoute from 'app/ResolveRoute';
 import DropdownMenu from 'app/components/elements/DropdownMenu';
 import shouldComponentUpdate from 'app/utils/shouldComponentUpdate';
 import HorizontalMenu from 'app/components/elements/HorizontalMenu';
+import normalizeProfile from 'app/utils/NormalizeProfile';
 
 function sortOrderToLink(so, topic, account) {
     if (so === 'home') return '/@' + account + '/feed';
@@ -113,27 +114,27 @@ class Header extends React.Component {
             page_title = `Stolen Account Recovery`;
         } else if (route.page === 'UserProfile') {
             user_name = route.params[0].slice(1);
-            const meta_data = this.props.account_meta.getIn([user_name, 'json_metadata']);
-            const meta_name = meta_data ? JSON.parse(meta_data).profile.name : "";
-            page_title = `${meta_name ? meta_name : ""} (@${user_name}) `;
+            const {name} = normalizeProfile(this.props.account_meta.getIn([user_name]).toJS());
+            const user_title = name ? `${name} (@${user_name}) ` : `@${user_name} `;
+            page_title = user_title;
             if(route.params[1] === "followers"){
-                page_title = `People following ${meta_name ? meta_name : ""} (@${user_name}) `;
+                page_title = "People following " + user_title;
             }
             if(route.params[1] === "followed"){
-                page_title = `People followed by ${meta_name ? meta_name : ""} (@${user_name}) `;
+                page_title = "People followed " + user_title;
             }
             if(route.params[1] === "curation-rewards"){
-                page_title = `Curation rewards by ${meta_name ? meta_name : ""} (@${user_name}) `;
+                page_title = "Curation rewards " + user_title;
             }
             if(route.params[1] === "author-rewards"){
-                page_title = `Author rewards by ${meta_name ? meta_name : ""} (@${user_name}) `;
+                page_title = "Author rewards by " + user_title;
             }
             if(route.params[1] === "recent-replies"){
-                page_title = `Replies to ${meta_name ? meta_name : ""} (@${user_name}) `;
+                page_title = "Replies to " + user_title;
             }
             // @user/"posts" is deprecated in favor of "comments" as of oct-2016 (#443)
             if(route.params[1] === "posts" || route.params[1] === "comments"){
-                page_title = `Comments by ${meta_name ? meta_name : ""} (@${user_name}) `;
+                page_title = "Comments by " + user_title;
             }
         } else {
             page_name = ''; //page_title = route.page.replace( /([a-z])([A-Z])/g, '$1 $2' ).toLowerCase();

--- a/app/components/modules/Header.jsx
+++ b/app/components/modules/Header.jsx
@@ -71,6 +71,7 @@ class Header extends React.Component {
         let topic = '';
         let user_name = null;
         let page_name = null;
+
         if (route.page === 'PostsIndex') {
             sort_order = route.params[0];
             if (sort_order === 'home') {
@@ -115,16 +116,16 @@ class Header extends React.Component {
         } else if (route.page === 'UserProfile') {
             user_name = route.params[0].slice(1);
             const {name} = normalizeProfile(this.props.account_meta.getIn([user_name]).toJS());
-            const user_title = name ? `${name} (@${user_name}) ` : `@${user_name} `;
+            const user_title = name ? `${name} (@${user_name})` : user_name;
             page_title = user_title;
             if(route.params[1] === "followers"){
                 page_title = "People following " + user_title;
             }
             if(route.params[1] === "followed"){
-                page_title = "People followed " + user_title;
+                page_title = "People followed by " + user_title;
             }
             if(route.params[1] === "curation-rewards"){
-                page_title = "Curation rewards " + user_title;
+                page_title = "Curation rewards by " + user_title;
             }
             if(route.params[1] === "author-rewards"){
                 page_title = "Author rewards by " + user_title;

--- a/app/components/modules/Header.jsx
+++ b/app/components/modules/Header.jsx
@@ -17,7 +17,8 @@ function sortOrderToLink(so, topic, account) {
 class Header extends React.Component {
     static propTypes = {
         location: React.PropTypes.object.isRequired,
-        current_account_name: React.PropTypes.string
+        current_account_name: React.PropTypes.string,
+        account_meta: React.PropTypes.object
     };
 
     constructor() {
@@ -69,7 +70,6 @@ class Header extends React.Component {
         let topic = '';
         let user_name = null;
         let page_name = null;
-
         if (route.page === 'PostsIndex') {
             sort_order = route.params[0];
             if (sort_order === 'home') {
@@ -113,25 +113,27 @@ class Header extends React.Component {
             page_title = `Stolen Account Recovery`;
         } else if (route.page === 'UserProfile') {
             user_name = route.params[0].slice(1);
-            page_title = ` @${user_name}`;
+            const meta_data = this.props.account_meta.getIn([user_name, 'json_metadata']);
+            const meta_name = meta_data ? JSON.parse(meta_data).profile.name : "";
+            page_title = `${meta_name ? meta_name : ""} (@${user_name}) `;
             if(route.params[1] === "followers"){
-                page_title = `People following ${user_name} `;
+                page_title = `People following ${meta_name ? meta_name : ""} (@${user_name}) `;
             }
             if(route.params[1] === "followed"){
-                page_title = `People followed by ${user_name} `;
+                page_title = `People followed by ${meta_name ? meta_name : ""} (@${user_name}) `;
             }
             if(route.params[1] === "curation-rewards"){
-                page_title = `Curation rewards by ${user_name} `;
+                page_title = `Curation rewards by ${meta_name ? meta_name : ""} (@${user_name}) `;
             }
             if(route.params[1] === "author-rewards"){
-                page_title = `Author rewards by ${user_name} `;
+                page_title = `Author rewards by ${meta_name ? meta_name : ""} (@${user_name}) `;
             }
             if(route.params[1] === "recent-replies"){
-                page_title = `Replies to ${user_name} `;
+                page_title = `Replies to ${meta_name ? meta_name : ""} (@${user_name}) `;
             }
             // @user/"posts" is deprecated in favor of "comments" as of oct-2016 (#443)
             if(route.params[1] === "posts" || route.params[1] === "comments"){
-                page_title = `Comments by ${user_name} `;
+                page_title = `Comments by ${meta_name ? meta_name : ""} (@${user_name}) `;
             }
         } else {
             page_name = ''; //page_title = route.page.replace( /([a-z])([A-Z])/g, '$1 $2' ).toLowerCase();
@@ -211,10 +213,12 @@ export {Header as _Header_};
 export default connect(
     state => {
         const current_user = state.user.get('current');
+        const account_user = state.global.get('accounts');
         const current_account_name = current_user ? current_user.get('username') : state.offchain.get('account');
         return {
             location: state.app.get('location'),
-            current_account_name
+            current_account_name,
+            account_meta: account_user
         }
     }
 )(Header);

--- a/app/utils/ExtractContent.js
+++ b/app/utils/ExtractContent.js
@@ -77,7 +77,7 @@ export default function extractContent(get, content) {
         // Remove bold and header, etc.
         // Stripping removes links with titles (so we got the links above)..
         // Remove block quotes if detected comment preview
-        const body2 = remarkableStripper.render(content.get('depth') > 1 ? body.replace(/>([\s\S]*?).*\s*/g,'') : body);
+        const body2 = remarkableStripper.render(content.depth > 1 ? body.replace(/>([\s\S]*?).*\s*/g,'') : body);
         desc = sanitize(body2, {allowedTags: []})// remove all html, leaving text
         desc = htmlDecode(desc)
 

--- a/app/utils/ExtractContent.js
+++ b/app/utils/ExtractContent.js
@@ -77,7 +77,7 @@ export default function extractContent(get, content) {
         // Remove bold and header, etc.
         // Stripping removes links with titles (so we got the links above)..
         // Remove block quotes if detected comment preview
-        const body2 = remarkableStripper.render(content.depth > 1 ? body.replace(/>([\s\S]*?).*\s*/g,'') : body);
+        const body2 = remarkableStripper.render(get(content, 'depth') > 1 ? body.replace(/>([\s\S]*?).*\s*/g,'') : body);
         desc = sanitize(body2, {allowedTags: []})// remove all html, leaving text
         desc = htmlDecode(desc)
 

--- a/app/utils/ExtractMeta.js
+++ b/app/utils/ExtractMeta.js
@@ -1,5 +1,6 @@
 import extractContent from 'app/utils/ExtractContent';
 import {objAccessor} from 'app/utils/Accessors';
+import normalizeProfile from 'app/utils/NormalizeProfile';
 
 const site_desc = 'Steemit the social media platform where everyone gets paid for creating and curating content. It leverages the robust digital points system Steem for digital rewards.';
 
@@ -37,7 +38,6 @@ export default function extractMeta(chain_data, rp) {
             metas.push({title});
             metas.push({canonical: url});
             metas.push({name: 'description', content: desc});
-            metas.push({name: 'keywords', content: "steem, steemit, posts, news"});
 
             // Open Graph data
             metas.push({property: 'og:title',        content: title});
@@ -61,23 +61,24 @@ export default function extractMeta(chain_data, rp) {
         }
     } else if (rp.accountname) { // user profile root
         const account = chain_data.accounts[rp.accountname];
-        const jsonMetadata = JSON.parse(account.json_metadata);
-
+        let {name, about, profile_image} = normalizeProfile(account);
+        if(name == null) name = account.name;
+        if(about == null) about = " Steemit";
+        if(profile_image == null) profile_image = 'https://steemit.com/images/steemit-twshare.png';
         // Set profile tags
         const title = `@${account.name}`;
-        const desc  = `${jsonMetadata.profile.name} (@${account.name}). ${jsonMetadata.profile.about}`;
-        const image = jsonMetadata.profile.profile_image;
+        const desc  = `The latest posts from ${name}. Follow me at @${account.name}. ${about}`;
+        const image = profile_image;
 
         // Standard meta
         metas.push({name: 'description', content: desc.substring(0,170)});
-        metas.push({name: 'keywords', content: `@${account.name}, ${jsonMetadata.profile.name}, steem, steemit, profile`});
 
         // Twitter card data
         metas.push({name: 'twitter:card',        content: 'summary'});
         metas.push({name: 'twitter:site',        content: '@steemit'});
         metas.push({name: 'twitter:title',       content: title});
         metas.push({name: 'twitter:description', content: desc});
-        metas.push({name: 'twitter:image',       content: image || 'https://steemit.com/images/steemit-twshare.png'});
+        metas.push({name: 'twitter:image',       content: image});
     } else { // site
         addSiteMeta(metas);
     }

--- a/app/utils/ExtractMeta.js
+++ b/app/utils/ExtractMeta.js
@@ -6,6 +6,7 @@ const site_desc = 'Steemit is a social media platform where everyone gets paid f
 function addSiteMeta(metas) {
     metas.push({title: 'Steemit'});
     metas.push({name: 'description', content: site_desc});
+    metas.push({name: 'keywords', content: "steem, steemit, blockchain, news, posts"});
     metas.push({property: 'og:type', content: 'website'});
     metas.push({property: 'og:site_name', content: 'Steemit'});
     metas.push({property: 'og:title', content: 'Steemit'});
@@ -35,7 +36,8 @@ export default function extractMeta(chain_data, rp) {
             // Standard meta
             metas.push({title});
             metas.push({canonical: url});
-            metas.push({name: 'description',         content: desc});
+            metas.push({name: 'description', content: desc});
+            metas.push({name: 'keywords', content: "steem steemit posts news"});
 
             // Open Graph data
             metas.push({property: 'og:title',        content: title});
@@ -57,6 +59,25 @@ export default function extractMeta(chain_data, rp) {
         } else {
             addSiteMeta(metas);
         }
+    } else if (rp.accountname && chain_data.accounts) { // user profile
+        const account = chain_data.accounts[rp.accountname];
+        const jsonMetadata = JSON.parse(account.json_metadata);
+
+        // Set profile tags
+        const title = `@${account.name}`;
+        const desc  = `The latest posts by ${jsonMetadata.profile.name} (@${account.name}). ${jsonMetadata.profile.about}`;
+        const image = jsonMetadata.profile.profile_image;
+
+        // Standard meta
+        metas.push({name: 'description', content: desc});
+        metas.push({name: 'keywords', content: `@${account.name}, ${jsonMetadata.profile.name}, ${jsonMetadata.profile.about}, steem, steemit`});
+
+        // Twitter card data
+        metas.push({name: 'twitter:card',        content: 'summary'});
+        metas.push({name: 'twitter:site',        content: '@steemit'});
+        metas.push({name: 'twitter:title',       content: title});
+        metas.push({name: 'twitter:description', content: desc});
+        metas.push({name: 'twitter:image',       content: image || 'https://steemit.com/images/steemit-twshare.png'});
     } else { // site
         addSiteMeta(metas);
     }

--- a/app/utils/ExtractMeta.js
+++ b/app/utils/ExtractMeta.js
@@ -1,7 +1,7 @@
 import extractContent from 'app/utils/ExtractContent';
 import {objAccessor} from 'app/utils/Accessors';
 
-const site_desc = 'Steemit is a social media platform where everyone gets paid for creating and curating content. It leverages a robust digital points system, called Steem, that supports real value for digital rewards through market price discovery and liquidity';
+const site_desc = 'Steemit the social media platform where everyone gets paid for creating and curating content. It leverages the robust digital points system Steem for digital rewards.';
 
 function addSiteMeta(metas) {
     metas.push({title: 'Steemit'});

--- a/app/utils/ExtractMeta.js
+++ b/app/utils/ExtractMeta.js
@@ -59,18 +59,18 @@ export default function extractMeta(chain_data, rp) {
         } else {
             addSiteMeta(metas);
         }
-    } else if (rp.accountname && chain_data.accounts) { // user profile
+    } else if (rp.accountname) { // user profile root
         const account = chain_data.accounts[rp.accountname];
         const jsonMetadata = JSON.parse(account.json_metadata);
 
         // Set profile tags
         const title = `@${account.name}`;
-        const desc  = `The latest posts by ${jsonMetadata.profile.name} (@${account.name}). ${jsonMetadata.profile.about}`;
+        const desc  = `${jsonMetadata.profile.name} (@${account.name}). ${jsonMetadata.profile.about}`;
         const image = jsonMetadata.profile.profile_image;
 
         // Standard meta
-        metas.push({name: 'description', content: desc});
-        metas.push({name: 'keywords', content: `@${account.name}, ${jsonMetadata.profile.name}, ${jsonMetadata.profile.about}, steem, steemit`});
+        metas.push({name: 'description', content: desc.substring(0,170)});
+        metas.push({name: 'keywords', content: `@${account.name}, ${jsonMetadata.profile.name}, steem, steemit, profile`});
 
         // Twitter card data
         metas.push({name: 'twitter:card',        content: 'summary'});

--- a/app/utils/ExtractMeta.js
+++ b/app/utils/ExtractMeta.js
@@ -37,7 +37,7 @@ export default function extractMeta(chain_data, rp) {
             metas.push({title});
             metas.push({canonical: url});
             metas.push({name: 'description', content: desc});
-            metas.push({name: 'keywords', content: "steem steemit posts news"});
+            metas.push({name: 'keywords', content: "steem, steemit, posts, news"});
 
             // Open Graph data
             metas.push({property: 'og:title',        content: title});

--- a/app/utils/ExtractMeta.js
+++ b/app/utils/ExtractMeta.js
@@ -2,7 +2,7 @@ import extractContent from 'app/utils/ExtractContent';
 import {objAccessor} from 'app/utils/Accessors';
 import normalizeProfile from 'app/utils/NormalizeProfile';
 
-const site_desc = 'Steemit the social media platform where everyone gets paid for creating and curating content. It leverages the robust digital points system Steem for digital rewards.';
+const site_desc = 'Steemit: the social media platform where everyone gets paid for creating and curating content. It leverages a robust digital points system (Steem) for digital rewards.';
 
 function addSiteMeta(metas) {
     metas.push({title: 'Steemit'});

--- a/app/utils/ExtractMeta.js
+++ b/app/utils/ExtractMeta.js
@@ -7,7 +7,6 @@ const site_desc = 'Steemit the social media platform where everyone gets paid fo
 function addSiteMeta(metas) {
     metas.push({title: 'Steemit'});
     metas.push({name: 'description', content: site_desc});
-    metas.push({name: 'keywords', content: "steem, steemit, blockchain, news, posts"});
     metas.push({property: 'og:type', content: 'website'});
     metas.push({property: 'og:site_name', content: 'Steemit'});
     metas.push({property: 'og:title', content: 'Steemit'});

--- a/app/utils/ExtractMeta.js
+++ b/app/utils/ExtractMeta.js
@@ -62,15 +62,15 @@ export default function extractMeta(chain_data, rp) {
         const account = chain_data.accounts[rp.accountname];
         let {name, about, profile_image} = normalizeProfile(account);
         if(name == null) name = account.name;
-        if(about == null) about = " Steemit";
+        if(about == null) about = " Join thousands on steemit who share, post and earn rewards.";
         if(profile_image == null) profile_image = 'https://steemit.com/images/steemit-twshare.png';
         // Set profile tags
         const title = `@${account.name}`;
-        const desc  = `The latest posts from ${name}. Follow me at @${account.name}. ${about}`;
+        const desc  = `The latest posts from ${name}. Follow me at @${account.name}. ${about}.`;
         const image = profile_image;
 
         // Standard meta
-        metas.push({name: 'description', content: desc.substring(0,170)});
+        metas.push({name: 'description', content: desc});
 
         // Twitter card data
         metas.push({name: 'twitter:card',        content: 'summary'});

--- a/app/utils/ExtractMeta.js
+++ b/app/utils/ExtractMeta.js
@@ -2,7 +2,7 @@ import extractContent from 'app/utils/ExtractContent';
 import {objAccessor} from 'app/utils/Accessors';
 import normalizeProfile from 'app/utils/NormalizeProfile';
 
-const site_desc = 'Steemit: the social media platform where everyone gets paid for creating and curating content. It leverages a robust digital points system (Steem) for digital rewards.';
+const site_desc = 'Steemit is a social media platform where everyone gets paid for creating and curating content. It leverages a robust digital points system (Steem) for digital rewards.';
 
 function addSiteMeta(metas) {
     metas.push({title: 'Steemit'});
@@ -62,11 +62,11 @@ export default function extractMeta(chain_data, rp) {
         const account = chain_data.accounts[rp.accountname];
         let {name, about, profile_image} = normalizeProfile(account);
         if(name == null) name = account.name;
-        if(about == null) about = " Join thousands on steemit who share, post and earn rewards.";
+        if(about == null) about = "Join thousands on steemit who share, post and earn rewards.";
         if(profile_image == null) profile_image = 'https://steemit.com/images/steemit-twshare.png';
         // Set profile tags
         const title = `@${account.name}`;
-        const desc  = `The latest posts from ${name}. Follow me at @${account.name}. ${about}.`;
+        const desc  = `The latest posts from ${name}. Follow me at @${account.name}. ${about}`;
         const image = profile_image;
 
         // Standard meta


### PR DESCRIPTION
This is a revamp for meta, seo improvements on profile pages(and site wide pages) for serps. 

Example of current google result for "neil strauss" steemit profile page. 
<img width="644" alt="screen shot 2017-01-13 at 1 07 37 pm" src="https://cloud.githubusercontent.com/assets/1158463/21940236/68b6dcb0-d991-11e6-9d34-70393e524be3.png">

New profile improvements:

A. Title's will now read with meta name(if available). Example: "Neil Strauss (@neilstrauss)"  
B. User profile pages now have unique meta descriptions(capped at 170 char).  Instead of showing random text profile serp results will now reflect a username and meta name and about. 
C. User profile/and children now have meta tags. 
D. User profile pages have unique twitter card og tags.  If users share their profile they will have their profile image and name in the share card. 

Examples:
Current profile meta state:
<img width="587" alt="screen shot 2017-01-13 at 1 19 31 pm" src="https://cloud.githubusercontent.com/assets/1158463/21940587/fcc98334-d992-11e6-9be1-f2237d673d19.png">
New profile meta state:
<img width="600" alt="screen shot 2017-01-13 at 1 19 23 pm" src="https://cloud.githubusercontent.com/assets/1158463/21940588/fe5810a8-d992-11e6-9ed7-656bc41d3d2e.png">

New steemit site wide improvements:

A. Meta Description is now limited to 170 char for no serp over limit
B. Inclusion of keyword tags