### PR TITLE
#844 protect for invalid user pages allow for short post urls

### DIFF
--- a/shared/UniversalRender.jsx
+++ b/shared/UniversalRender.jsx
@@ -147,8 +147,14 @@ async function universalRender({ location, initial_state, offchain }) {
         if (!url.match(routeRegex.PostsIndex) && !url.match(routeRegex.UserProfile1) && !url.match(routeRegex.UserProfile2) && url.match(routeRegex.PostNoCategory)) {
             const params = url.substr(2, url.length - 1).split("/");
             const content = await Apis.instance().db_api.exec('get_content', [params[0], params[1]]);
-            if (content) {
+            if (content.author && content.permlink) { // valid short post url
                 onchain.content[url.substr(2, url.length - 1)] = content;
+            } else { // protect on invalid user pages (i.e /user/transferss)
+                return {
+                    title: 'Page Not Found - Steemit',
+                    statusCode: 404,
+                    body: renderToString(<NotFound />)
+                };
             }
         }
         // Calculate signup bonus


### PR DESCRIPTION
This addresses a few route issues.  Examples below. 

1.  @ats-david/transferss - all invalid user pages now properly 404(no spinning status).  
2.  @ats-david/a-walk-in-the-park-my-journey-through-images-volume-ii-nothing-here - all invalid short posts now properly 404(no spinning status)
3. This all preserves short post url linking