### PR TITLE
Update Resteem Confirm to "Resteem This Post as @username"

### DIFF
--- a/app/components/elements/Reblog.jsx
+++ b/app/components/elements/Reblog.jsx
@@ -87,7 +87,7 @@ module.exports = connect(
                     id: 'follow',
                     required_posting_auths: [account],
                     json: JSON.stringify(json),
-                    __config: {title: 'Resteem This Post'}
+                    __config: {title: 'Resteem This Post as @' + account}
                 },
                 successCallback, errorCallback,
             }))


### PR DESCRIPTION
For users who use multiple accounts, it is easy to accidentally resteem under the wrong account.

The current Resteem confirmation looks like this:
![image](https://cloud.githubusercontent.com/assets/20735105/22132052/30b7c478-de7d-11e6-8e20-dcc827486bad.png)


This update will change it so that the confirmation includes the username of the logged in user:
![image](https://cloud.githubusercontent.com/assets/20735105/22132023/087a06e2-de7d-11e6-80fa-4b092c9c6f2a.png)

If there are any changes to the logic/formatting/etc. that would be preferred over this implementation, just let me know and I can make the necessary updates.