### PR TITLE
Do not show how many flags a post has received

### DIFF
--- a/app/components/cards/PostSummary.jsx
+++ b/app/components/cards/PostSummary.jsx
@@ -178,7 +178,7 @@ class PostSummary extends React.Component {
 
         return (
             <article className={'PostSummary hentry' + (thumb ? ' with-image ' : ' ') + commentClasses.join(' ')} itemScope itemType ="http://schema.org/blogPost">
-                <div className={hasFlag ? '' : 'PostSummary__collapse'}>
+                <div className="PostSummary__collapse">
                     <div className="float-right"><Voting post={post} flag /></div>
                 </div>
                 {reblogged_by}

--- a/app/components/elements/Voting.jsx
+++ b/app/components/elements/Voting.jsx
@@ -146,7 +146,6 @@ class Voting extends React.Component {
             const flagClickAction = myVote === null || myVote === 0 ? this.toggleWeightDown : this.voteDown
             return <span className="Voting">
                 <span className={classDown}>
-                    {down_votes > 0 && <span className="Voting__button-downvotes">{down_votes}</span>}
                     {votingDownActive ? down : <a href="#" onClick={flagClickAction} title="Flag">{down}</a>}
                     {dropdown}
                 </span>


### PR DESCRIPTION
This pull request updates the UI so that flagged posts do not stand out compared to non-flagged posts.

**Reasoning:**
With the current implementation of "flags" and "downvotes" being combined into the same function, users receiving "downvotes" for non-abusive reasons such as disagreement on rewards has been causing a lot of controversy. Part of the reason is because the interface shows the post as 'flagged' whenever it receives a downvote, which makes the post seem 'bad' compared to non-flagged posts, even if the poster did nothing 'wrong'.

The main argument against this change will be that users can no longer easily identify posts that have been flagged for abusive reasons. While this is true, the current implementation of the flag/downvote at a blockchain level does not provide a good means to do this without also singling out content that has been downvoted for non-abusive reasons. Users that are interested in fighting abuse can use other interfaces (such as steemd or the steemit.chat abuse channel) for this purpose, while regular users will just be presented with the "vote list" (showing the top 20 upvotes/downvotes) and pending post reward.

Ultimately, a more robust long-term solution should be pursued that gives the user the ability to 'flag' or 'downvote' separately, with a way to distinguish between the two.

**The pull request makes two changes:**
- Removes the flag counter, so the UI no longer shows a count of how many flags a post has received.
- Changes the post preview to only show the flag icon when a user hovers over the post. (This is the same behavior as a non-flagged post.)

Here is an example of what flagged posts will look like with the change:
![image](https://cloud.githubusercontent.com/assets/20735105/22158856/ef22e1fa-df03-11e6-9d31-8fbde8db49ad.png)

Compared to the current UI:
![image](https://cloud.githubusercontent.com/assets/20735105/22158870/ff13b22e-df03-11e6-9e54-d689524a8e46.png)

The UI will show the flag icon when the user does a mouseover of the post, which is the same behavior as a non-flagged post:
![image](https://cloud.githubusercontent.com/assets/20735105/22158920/2cf9f798-df04-11e6-82a1-f84c225f2803.png)

If the logged in user has flagged a post, the mouseover will show that post with the red 'flagged' icon, so that the user can still tell if they have flagged the post:
![image](https://cloud.githubusercontent.com/assets/20735105/22158960/60b392ce-df04-11e6-872f-e1f92227e34c.png)

Posts and comments that have been flagged to the point of having a negative voting score will still be hidden (the same as before):
![image](https://cloud.githubusercontent.com/assets/20735105/22159505/d60f47e6-df06-11e6-9db5-83c40793c5ba.png)

The downvotes will still be shown in the "vote list", with the same logic as upvotes:
![image](https://cloud.githubusercontent.com/assets/20735105/22159357/0e4aba38-df06-11e6-82a4-eee79ff91d82.png)

Since this is likely going to be a controversial change, I will create a Steemit post describing the PR, to facilitate discussion with the community.