### PR TITLE
Move the "Steemit Chat" link higher in the main menu

### DIFF
--- a/app/components/App.jsx
+++ b/app/components/App.jsx
@@ -181,6 +181,11 @@ class App extends React.Component {
                         </a>
                     </li>
                     <li>
+                        <a href="https://steemit.chat/home" target="_blank" rel="noopener noreferrer">
+                            {translate("APP_NAME_chat")}&nbsp;<Icon name="extlink" />
+                        </a>
+                    </li>
+                    <li>
                         <a onClick={() => depositSteem()}>
                             {translate("buy_LIQUID_TOKEN")}
                         </a>
@@ -203,11 +208,6 @@ class App extends React.Component {
                     <li>
                         <a href="/change_password" onClick={this.navigate}>
                             {translate("change_account_password")}
-                        </a>
-                    </li>
-                    <li>
-                        <a href="https://steemit.chat/home" target="_blank" rel="noopener noreferrer">
-                            {translate("APP_NAME_chat")}&nbsp;<Icon name="extlink" />
                         </a>
                     </li>
                     <li>


### PR DESCRIPTION
The "Steemit Chat" link is a frequently used link by many users. This PR moves the "Steemit Chat" link higher in the menu, so it is easier to get to.

![image](https://cloud.githubusercontent.com/assets/20735105/22615735/006b46ba-ea61-11e6-84d4-6729281b0c91.png)
