### PR TITLE
Move witness proxy voting to the bottom of the witness voting page

### DIFF
--- a/app/components/pages/Witnesses.jsx
+++ b/app/components/pages/Witnesses.jsx
@@ -134,35 +134,6 @@ class Witnesses extends React.Component {
                     </div>
                 </div>
 
-                <div className="row">
-                    <div className="column">
-                        <p>{translate(current_proxy && current_proxy.length ? 'witness_set' : 'set_witness_proxy', {proxy: current_proxy})}</p>
-                        {current_proxy && current_proxy.length ?
-                        <div>
-                            <div style={{paddingBottom: 10}}>{translate("witness_proxy_current")}: <strong>{}</strong></div>
-
-                            <form>
-                                <div className="input-group">
-                                    <input className="input-group-field bold" disabled type="text" style={{float: "left", width: "75%", maxWidth: "20rem"}} value={current_proxy} />
-                                    <div className="input-group-button">
-                                        <button style={{marginBottom: 0}} className="button" onClick={accountWitnessProxy}>{translate('witness_proxy_clear')}</button>
-                                    </div>
-                                </div>
-                            </form>
-                        </div> :
-                        <form>
-                            <div className="input-group">
-                                <input className="input-group-field bold" type="text" style={{float: "left", width: "75%", maxWidth: "20rem"}} value={proxy} onChange={(e) => {this.setState({proxy: e.target.value});}} />
-                                <div className="input-group-button">
-                                    <button style={{marginBottom: 0}} className="button" onClick={accountWitnessProxy}>{translate('witness_proxy_set')}</button>
-                                </div>
-                            </div>
-                        </form>}
-                        {this.state.proxyFailed && <p className="error">{translate("proxy_update_error")}.</p>}
-                        <br />
-                     </div>
-                </div>
-
                 {current_proxy && current_proxy.length ? null :
                 <div className="row small-collapse">
                     <div className="column">
@@ -198,6 +169,35 @@ class Witnesses extends React.Component {
                         <br /><br />
                      </div>
                 </div>}
+
+                <div className="row">
+                    <div className="column">
+                        <p>{translate(current_proxy && current_proxy.length ? 'witness_set' : 'set_witness_proxy', {proxy: current_proxy})}</p>
+                        {current_proxy && current_proxy.length ?
+                        <div>
+                            <div style={{paddingBottom: 10}}>{translate("witness_proxy_current")}: <strong>{}</strong></div>
+
+                            <form>
+                                <div className="input-group">
+                                    <input className="input-group-field bold" disabled type="text" style={{float: "left", width: "75%", maxWidth: "20rem"}} value={current_proxy} />
+                                    <div className="input-group-button">
+                                        <button style={{marginBottom: 0}} className="button" onClick={accountWitnessProxy}>{translate('witness_proxy_clear')}</button>
+                                    </div>
+                                </div>
+                            </form>
+                        </div> :
+                        <form>
+                            <div className="input-group">
+                                <input className="input-group-field bold" type="text" style={{float: "left", width: "75%", maxWidth: "20rem"}} value={proxy} onChange={(e) => {this.setState({proxy: e.target.value});}} />
+                                <div className="input-group-button">
+                                    <button style={{marginBottom: 0}} className="button" onClick={accountWitnessProxy}>{translate('witness_proxy_set')}</button>
+                                </div>
+                            </div>
+                        </form>}
+                        {this.state.proxyFailed && <p className="error">{translate("proxy_update_error")}.</p>}
+                        <br />
+                     </div>
+                </div>
             </div>
         );
     }


### PR DESCRIPTION
The witness voting proxy is an excellent feature to have in the GUI, but it is a feature that is only useful to a subset of users. Having at the top of the witness voting page does not seem like the best placement, since (hopefully) the "average" user is going to want to be involved in the witness voting process and vote for witnesses themselves.

![image](https://cloud.githubusercontent.com/assets/20735105/22620352/d26b457a-eacf-11e6-95d0-2ca4405a21e4.png)

This pull request moves the witness voting proxy to the bottom of the witness voting page.

![image](https://cloud.githubusercontent.com/assets/20735105/22620361/f3b62826-eacf-11e6-982e-69a2ff05e483.png)

I have verified that the functionality still works as expected when placed at the bottom of the page.

![image](https://cloud.githubusercontent.com/assets/20735105/22620366/09ae1468-ead0-11e6-8435-49da7841c8c8.png)
